### PR TITLE
Caching the capabilities of a user

### DIFF
--- a/classes/capability_helper.php
+++ b/classes/capability_helper.php
@@ -1,0 +1,50 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Class to support request for capability.
+ * @package    tool_lifecycle
+ * @copyright  2018 Tobias Reischmann, Nina Herrmann WWU
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+namespace tool_lifecycle;
+
+defined('MOODLE_INTERNAL') || die;
+
+class capability_helper {
+    /**
+     * Looks whether managedcourses are cached and returns an array of managed courses.
+     * @return array|bool
+     */
+    public static function has_coursesmanaged() {
+        global $USER;
+        $userid = $USER->id;
+        $cache = \cache::make('tool_lifecycle', 'coursesmanaged');
+        $cachedcourses = $cache->get($userid);
+        if ($cachedcourses === false) {
+            $courses = get_user_capability_course('tool/lifecycle:managecourses', $userid, false);
+            // No course with capabilities.
+            if ($courses === false) {
+                $cache->set($userid, 0);
+            } else {
+                $cache->set($userid, 1);
+            }
+            $cachedcourses = $cache->get($userid);
+
+        }
+        return $cachedcourses;
+    }
+}

--- a/classes/observer.php
+++ b/classes/observer.php
@@ -1,0 +1,45 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * @package    tool_lifecycle
+ * @copyright  2018 Tobias Reischmann, Nina Herrmann WWU
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+namespace tool_lifecycle;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Class observer - implements the function which react on changes which affect the cached value tool_lifecycle course managed.
+ */
+class observer {
+
+    /**
+     * Function which invalidates the tool_lifecycle course managed cache at the key for the corresponding user
+     * when his/her role is changed.
+     * @param \core\event\role_assigned || \core\event\role_deleted $event
+     * @throws \coding_exception
+     */
+    public static function role_changed($event) {
+        $component = 'tool_lifecycle';
+        $area = 'coursesmanaged';
+        $userid = $event->relateduserid;
+
+        // FYI: Although this method is called invalidate it actually deletes the cache at the given key.
+        \cache_helper::invalidate_by_definition($component, $area, array(), $userid);
+    }
+}

--- a/db/caches.php
+++ b/db/caches.php
@@ -1,0 +1,41 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * @package    tool_lifecycle
+ * @copyright  2018 Tobias Reischmann, Nina Herrmann WWU
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * For values for default settings look at https://docs.moodle.org/dev/Cache_API#Ad-hoc_Caches.
+ *
+ * The cache has a key for each user (userid). The key stores a 1 in case the user has at least one course where he/she can
+ * manage the lifecycle of the course. Otherwise a 0 is stored.
+ * You might wonder why this is a application cache and not rather a session cache with only one key. The problem is that
+ * certain events require to invalidate the cache. E.g. when a new role is assigned or a course is created.
+ * When using session caches events triggered in a different session can not invalidated the caches in the current session.
+ * Therefore, an application cache is used which can be invalidated across different sessions.
+ * The main disadvantage is that the space in the application cache is occupied. However, since only one key is invalidated
+ * per event, at least sessions from other users are not affected since they do not request the key.
+ * */
+$definitions = array(
+    'coursesmanaged' => array(
+        'mode' => cache_store::MODE_APPLICATION,
+        'simplekeys' => true)
+);

--- a/db/events.php
+++ b/db/events.php
@@ -15,15 +15,20 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Version details.
- *
  * @package    tool_lifecycle
- * @copyright  2017 Tobias Reischmann WWU
+ * @copyright  2018 Tobias Reischmann, Nina Herrmann WWU
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die;
-
-$plugin->maturity = MATURITY_ALPHA;
-$plugin->version  = 2018042001;
-$plugin->component = 'tool_lifecycle';
-$plugin->requires = 2017051500; // Require Moodle 3.3 (or above).
+defined('MOODLE_INTERNAL') || die();
+$observers = array(
+    // Create or delete course is not considered since in this case the role_assigned or role_unassigned event is thrown.
+    array(
+        'eventname'   => '\core\event\role_assigned',
+        'callback'    => 'tool_lifecycle\observer::role_changed'
+    ),
+    array(
+        'eventname'   => '\core\event\role_unassigned',
+        'callback'    => 'tool_lifecycle\observer::role_changed'
+    )
+);

--- a/lang/en/tool_lifecycle.php
+++ b/lang/en/tool_lifecycle.php
@@ -126,3 +126,5 @@ $string['manual_trigger_process_existed'] = 'A workflow for this course already 
 
 $string['workflow_started'] = 'Workflow started.';
 $string['workflow_is_running'] = 'Workflow is running.';
+
+$string['cachedef_coursesmanaged'] = 'Caches for which courses a user has the capability tool/lifecycle:managecourses';


### PR DESCRIPTION
Knowing the capability of a user is necessary to decide whether the user should see a reference in the navigation to manage courses. Since this information is needed every time the navigation is displayed (so nearly for every page call) the information should be cached.
This cache is now implemented and invalidated for users whose role is changed. 

As extra information for the cache: 
The cache has a key for each user (userid). The key stores a 1 in case the user has at least one course where he/she can manage the lifecycle of the course. Otherwise a 0 is stored.
One might wonder why this is a application cache and not rather a session cache with only one key. The problem is that certain events require to invalidate the cache. When using session caches events triggered in a session can not invalidated caches from another session. Therefore, an application cache is used which can be invalidated across different sessions. The main disadvantage is that more space in the application cache is occupied (Since every for each user data is stored). However, since only one key is invalidated per event, sessions from other users are not affected since they do not request the key. Therefore, additional space is taken but the request does not cause to reload the whole cache. 