### PR TITLE
Adding help icons near to form labels.

### DIFF
--- a/classes/form/form_step_instance.php
+++ b/classes/form/form_step_instance.php
@@ -108,10 +108,12 @@ class form_step_instance extends \moodleform {
 
         $elementname = 'instancename';
         $mform->addElement('text', $elementname, get_string('step_instancename', 'tool_lifecycle'));
+        $mform->addHelpButton($elementname, 'step_instancename', 'tool_lifecycle');
         $mform->setType($elementname, PARAM_TEXT);
 
         $elementname = 'subpluginnamestatic';
         $mform->addElement('static', $elementname, get_string('step_subpluginname', 'tool_lifecycle'));
+        $mform->addHelpButton($elementname, 'step_subpluginname', 'tool_lifecycle');
         $mform->setType($elementname, PARAM_TEXT);
         $elementname = 'subpluginname';
         $mform->addElement('hidden', $elementname);

--- a/classes/form/form_trigger_instance.php
+++ b/classes/form/form_trigger_instance.php
@@ -113,6 +113,7 @@ class form_trigger_instance extends \moodleform {
 
         $elementname = 'instancename';
         $mform->addElement('text', $elementname, get_string('trigger_instancename', 'tool_lifecycle'));
+        $mform->addHelpButton($elementname, 'trigger_instancename', 'tool_lifecycle');
         $mform->setType($elementname, PARAM_TEXT);
 
         $elementname = 'subpluginnamestatic';

--- a/classes/form/form_workflow_instance.php
+++ b/classes/form/form_workflow_instance.php
@@ -69,6 +69,7 @@ class form_workflow_instance extends \moodleform {
 
         $elementname = 'title';
         $mform->addElement('text', $elementname, get_string('workflow_title', 'tool_lifecycle'));
+        $mform->addHelpButton($elementname, 'workflow_title', 'tool_lifecycle');
         $mform->setType($elementname, PARAM_TEXT);
         if (isset($this->workflow)) {
             $mform->setDefault($elementname, $this->workflow->title);

--- a/lang/en/tool_lifecycle.php
+++ b/lang/en/tool_lifecycle.php
@@ -59,16 +59,16 @@ $string['error_wrong_trigger_selected'] = 'You tried to request a non-manual tri
 $string['lifecycle_task'] = 'Run the life cycle processes';
 
 $string['trigger_subpluginname'] = 'Subplugin Name';
-$string['trigger_subpluginname_help'] = 'Subplugin Name';
+$string['trigger_subpluginname_help'] = 'Choose the subplugin that you want to use for triggering. After selection, press "reload" to show the options for the subplugin.';
 $string['trigger_instancename'] = 'Instance Name';
-$string['trigger_instancename_help'] = 'Instance Name';
+$string['trigger_instancename_help'] = 'Trigger instance title (visible for admins only).';
 $string['trigger_enabled'] = 'Enabled';
 $string['trigger_sortindex'] = 'Up/Down';
 $string['trigger_workflow'] = 'Workflow';
 
 $string['add_workflow'] = 'Add Workflow';
 $string['workflow_title'] = 'Title';
-$string['workflow_title_help'] = 'Title';
+$string['workflow_title_help'] = 'Workflow title (visible for admins only).';
 $string['workflow_displaytitle'] = 'Displayed workflow title';
 $string['workflow_displaytitle_help'] = 'This title is displayed to users when managing their courses.';
 $string['workflow_active'] = 'Active';
@@ -85,9 +85,9 @@ $string['workflow_duplicate_title'] = '{$a} (Copy)';
 
 $string['step_type'] = 'Type';
 $string['step_subpluginname'] = 'Subplugin Name';
-$string['step_subpluginname_help'] = 'Subplugin Name';
+$string['step_subpluginname_help'] = 'Step subplugin/trigger title (visible for admins only).';
 $string['step_instancename'] = 'Instance Name';
-$string['step_instancename_help'] = 'Instance Name';
+$string['step_instancename_help'] = 'Step instance title (visible for admins only).';
 $string['step_sortindex'] = 'Up/Down';
 $string['step_edit'] = 'Edit';
 $string['step_show'] = 'Show';

--- a/lang/en/tool_lifecycle.php
+++ b/lang/en/tool_lifecycle.php
@@ -59,13 +59,16 @@ $string['error_wrong_trigger_selected'] = 'You tried to request a non-manual tri
 $string['lifecycle_task'] = 'Run the life cycle processes';
 
 $string['trigger_subpluginname'] = 'Subplugin Name';
+$string['trigger_subpluginname_help'] = 'Subplugin Name';
 $string['trigger_instancename'] = 'Instance Name';
+$string['trigger_instancename_help'] = 'Instance Name';
 $string['trigger_enabled'] = 'Enabled';
 $string['trigger_sortindex'] = 'Up/Down';
 $string['trigger_workflow'] = 'Workflow';
 
 $string['add_workflow'] = 'Add Workflow';
 $string['workflow_title'] = 'Title';
+$string['workflow_title_help'] = 'Title';
 $string['workflow_displaytitle'] = 'Displayed workflow title';
 $string['workflow_displaytitle_help'] = 'This title is displayed to users when managing their courses.';
 $string['workflow_active'] = 'Active';
@@ -82,7 +85,9 @@ $string['workflow_duplicate_title'] = '{$a} (Copy)';
 
 $string['step_type'] = 'Type';
 $string['step_subpluginname'] = 'Subplugin Name';
+$string['step_subpluginname_help'] = 'Subplugin Name';
 $string['step_instancename'] = 'Instance Name';
+$string['step_instancename_help'] = 'Instance Name';
 $string['step_sortindex'] = 'Up/Down';
 $string['step_edit'] = 'Edit';
 $string['step_show'] = 'Show';

--- a/step/duplicate/classes/form_duplicate.php
+++ b/step/duplicate/classes/form_duplicate.php
@@ -74,10 +74,12 @@ class form_duplicate extends \moodleform {
 
         $elementname = 'shortname';
         $mform->addElement('text', $elementname, get_string('shortnamecourse'));
+        $mform->addHelpButton($elementname, 'shortnamecourse');
         $mform->setType($elementname, PARAM_TEXT);
 
         $elementname = 'fullname';
         $mform->addElement('text', $elementname, get_string('fullnamecourse'));
+        $mform->addHelpButton($elementname, 'fullnamecourse');
         $mform->setType($elementname, PARAM_TEXT);
 
         $this->add_action_buttons();

--- a/step/email/lang/en/lifecyclestep_email.php
+++ b/step/email/lang/en/lifecyclestep_email.php
@@ -27,17 +27,17 @@ $string['pluginname'] = 'Email Step';
 
 $string['email_responsetimeout'] = 'Time the user has for the response';
 $string['email_subject'] = 'Subject Template';
-$email_placeholders_no_html =
+$emailplaceholdersnohtml =
     '<p>' . 'You can use the following placeholders:'
     . '<br>' . 'First name of recipient: ##firstname##'
     . '<br>' . 'Last name of recipient: ##lastname##'
     . '<br>' . 'Link to response page: ##link##'
     . '<br>' . 'Impacted courses: ##courses##'
     . '</p>';
-$string['email_subject_help'] = 'Set the template for the subject of the email.' . $email_placeholders_no_html;
+$string['email_subject_help'] = 'Set the template for the subject of the email.' . $emailplaceholdersnohtml;
 $string['email_content'] = 'Content plain text template';
-$string['email_content_help'] = 'Set the template for the content of the email (plain text, alternatively you can use HTML template for HTML email below)' . $email_placeholders_no_html ;
-$email_placeholders_html =
+$string['email_content_help'] = 'Set the template for the content of the email (plain text, alternatively you can use HTML template for HTML email below)' . $emailplaceholdersnohtml;
+$emailplaceholdershtml =
     '<p>' . 'You can use the following placeholders:'
     . '<br>' . 'First name of recipient: ##firstname##'
     . '<br>' . 'Last name of recipient: ##lastname##'
@@ -45,7 +45,7 @@ $email_placeholders_html =
     . '<br>' . 'Impacted courses: ##courses-html##'
     . '</p>';
 $string['email_content_html'] = 'Content HTML template';
-$string['email_content_html_help'] = 'Set the html template for the content of the email (HTML email, will be used instead of plaintext field if not empty!)' . $email_placeholders_html;
+$string['email_content_html_help'] = 'Set the html template for the content of the email (HTML email, will be used instead of plaintext field if not empty!)' . $emailplaceholdershtml;
 
 $string['email:preventdeletion'] = 'Prevent Deletion';
 

--- a/step/email/lang/en/lifecyclestep_email.php
+++ b/step/email/lang/en/lifecyclestep_email.php
@@ -27,8 +27,11 @@ $string['pluginname'] = 'Email Step';
 
 $string['email_responsetimeout'] = 'Time the user has for the response';
 $string['email_subject'] = 'Subject Template';
+$string['email_subject_help'] = 'Subject Template';
 $string['email_content'] = 'Content Template';
+$string['email_content_help'] = 'Content Template';
 $string['email_content_html'] = 'Content HTML Template';
+$string['email_content_html_help'] = 'Content HTML Template';
 $string['email:preventdeletion'] = 'Prevent Deletion';
 
 $string['keep_course'] = 'Keep Course';

--- a/step/email/lang/en/lifecyclestep_email.php
+++ b/step/email/lang/en/lifecyclestep_email.php
@@ -27,11 +27,26 @@ $string['pluginname'] = 'Email Step';
 
 $string['email_responsetimeout'] = 'Time the user has for the response';
 $string['email_subject'] = 'Subject Template';
-$string['email_subject_help'] = 'Subject Template';
-$string['email_content'] = 'Content Template';
-$string['email_content_help'] = 'Content Template';
-$string['email_content_html'] = 'Content HTML Template';
-$string['email_content_html_help'] = 'Content HTML Template';
+$email_placeholders_no_html =
+    '<p>' . 'You can use the following placeholders:'
+    . '<br>' . 'First name of recipient: ##firstname##'
+    . '<br>' . 'Last name of recipient: ##lastname##'
+    . '<br>' . 'Link to response page: ##link##'
+    . '<br>' . 'Impacted courses: ##courses##'
+    . '</p>';
+$string['email_subject_help'] = 'Set the template for the subject of the email.' . $email_placeholders_no_html;
+$string['email_content'] = 'Content plain text template';
+$string['email_content_help'] = 'Set the template for the content of the email (plain text, alternatively you can use HTML template for HTML email below)' . $email_placeholders_no_html ;
+$email_placeholders_html =
+    '<p>' . 'You can use the following placeholders:'
+    . '<br>' . 'First name of recipient: ##firstname##'
+    . '<br>' . 'Last name of recipient: ##lastname##'
+    . '<br>' . 'Link to response page: ##link-html##'
+    . '<br>' . 'Impacted courses: ##courses-html##'
+    . '</p>';
+$string['email_content_html'] = 'Content HTML template';
+$string['email_content_html_help'] = 'Set the html template for the content of the email (HTML email, will be used instead of plaintext field if not empty!)' . $email_placeholders_html;
+
 $string['email:preventdeletion'] = 'Prevent Deletion';
 
 $string['keep_course'] = 'Keep Course';

--- a/step/email/lang/en/lifecyclestep_email.php
+++ b/step/email/lang/en/lifecyclestep_email.php
@@ -44,7 +44,7 @@ $emailplaceholdershtml =
     . '<br>' . 'Link to response page: ##link-html##'
     . '<br>' . 'Impacted courses: ##courses-html##'
     . '</p>';
-$string['email_content_html'] = 'Content HTML template';
+$string['email_content_html'] = 'Content HTML Template';
 $string['email_content_html_help'] = 'Set the html template for the content of the email (HTML email, will be used instead of plaintext field if not empty!)' . $emailplaceholdershtml;
 
 $string['email:preventdeletion'] = 'Prevent Deletion';

--- a/step/email/lib.php
+++ b/step/email/lib.php
@@ -215,14 +215,17 @@ class email extends libbase {
         $mform->setType($elementname, PARAM_INT);
         $elementname = 'subject';
         $mform->addElement('text', $elementname, get_string('email_subject', 'lifecyclestep_email'));
+        $mform->addHelpButton($elementname, 'email_subject', 'lifecyclestep_email');
         $mform->setType($elementname, PARAM_TEXT);
 
         $elementname = 'content';
         $mform->addElement('textarea', $elementname, get_string('email_content', 'lifecyclestep_email'));
+        $mform->addHelpButton($elementname, 'email_content', 'lifecyclestep_email');
         $mform->setType($elementname, PARAM_TEXT);
 
         $elementname = 'contenthtml';
         $mform->addElement('editor', $elementname, get_string('email_content_html', 'lifecyclestep_email'));
+        $mform->addHelpButton($elementname, 'email_content_html', 'lifecyclestep_email');
         $mform->setType($elementname, PARAM_RAW);
     }
 

--- a/tests/behat/activate_workflow.feature
+++ b/tests/behat/activate_workflow.feature
@@ -28,7 +28,7 @@ Feature: Add a workflow definition activate it
       | responsetimeout[number]    | 14                          |
       | responsetimeout[timeunit]  | days                        |
       | Subject Template           | Subject                     |
-      | Content Template           | Content                     |
+      | Content plain text template           | Content                     |
       | Content HTML Template      | Content HTML                |
     And I press "Save changes"
     And I select "Create Backup Step" from the "stepname" singleselect

--- a/tests/behat/interaction.feature
+++ b/tests/behat/interaction.feature
@@ -34,7 +34,7 @@ Feature: Add a workflow with an email step and test the interaction as a teacher
       | responsetimeout[number]    | 8                           |
       | responsetimeout[timeunit]  | seconds                     |
       | Subject Template           | Subject                     |
-      | Content Template           | Content                     |
+      | Content plain text template           | Content                     |
       | Content HTML Template      | Content HTML                |
     And I press "Save changes"
     And I select "Delete Course Step" from the "stepname" singleselect

--- a/trigger/manual/lang/en/lifecycletrigger_manual.php
+++ b/trigger/manual/lang/en/lifecycletrigger_manual.php
@@ -25,5 +25,8 @@
 
 $string['pluginname'] = 'Manual trigger';
 $string['setting_capability'] = 'Capability';
+$string['setting_capability_help'] = 'Capability';
 $string['setting_icon'] = 'Icon';
+$string['setting_icon_help'] = 'Icon';
 $string['setting_displayname'] = 'Action name';
+$string['setting_displayname_help'] = 'Action name';

--- a/trigger/manual/lang/en/lifecycletrigger_manual.php
+++ b/trigger/manual/lang/en/lifecycletrigger_manual.php
@@ -25,8 +25,8 @@
 
 $string['pluginname'] = 'Manual trigger';
 $string['setting_capability'] = 'Capability';
-$string['setting_capability_help'] = 'Capability';
+$string['setting_capability_help'] = 'The Moodle Capability needed to see and invoke the trigger, e.g. "enrol/manual:enrol". Please see Moodle Access API documentation for details.';
 $string['setting_icon'] = 'Icon';
-$string['setting_icon_help'] = 'Icon';
+$string['setting_icon_help'] = 'The Moodle icon to be showed to the user for this trigger, e.g. "core/tick". A full list of possible icons can be found at Moodle documentation.';
 $string['setting_displayname'] = 'Action name';
-$string['setting_displayname_help'] = 'Action name';
+$string['setting_displayname_help'] = 'A name for the trigger action.';

--- a/trigger/manual/lib.php
+++ b/trigger/manual/lib.php
@@ -58,18 +58,21 @@ class manual extends base_manual {
         $mform->addElement(
             'text', $elementname, get_string('setting_icon', 'lifecycletrigger_manual')
         );
+        $mform->addHelpButton($elementname, 'setting_icon', 'lifecycletrigger_manual');
         $mform->setType($elementname, PARAM_SAFEPATH);
 
         $elementname = 'displayname';
         $mform->addElement(
             'text', $elementname, get_string('setting_displayname', 'lifecycletrigger_manual')
         );
+        $mform->addHelpButton($elementname, 'setting_displayname', 'lifecycletrigger_manual');
         $mform->setType($elementname, PARAM_TEXT);
 
         $elementname = 'capability';
         $mform->addElement(
             'text', $elementname, get_string('setting_capability', 'lifecycletrigger_manual')
         );
+        $mform->addHelpButton($elementname, 'setting_capability', 'lifecycletrigger_manual');
         $mform->setType($elementname, PARAM_CAPABILITY);
     }
 

--- a/trigger/startdatedelay/lang/en/lifecycletrigger_startdatedelay.php
+++ b/trigger/startdatedelay/lang/en/lifecycletrigger_startdatedelay.php
@@ -25,5 +25,5 @@
 
 $string['pluginname'] = 'Start date delay trigger';
 
-$string['delay'] = 'Delay from start of course til starting a process';
-$string['delay_help'] = 'Delay from start of course til starting a process';
+$string['delay'] = 'Delay from start of course until starting a process';
+$string['delay_help'] = 'The trigger will be invoked if the time passed since the course has started is longer than this delay.';

--- a/trigger/startdatedelay/lang/en/lifecycletrigger_startdatedelay.php
+++ b/trigger/startdatedelay/lang/en/lifecycletrigger_startdatedelay.php
@@ -26,3 +26,4 @@
 $string['pluginname'] = 'Start date delay trigger';
 
 $string['delay'] = 'Delay from start of course til starting a process';
+$string['delay_help'] = 'Delay from start of course til starting a process';

--- a/trigger/startdatedelay/lib.php
+++ b/trigger/startdatedelay/lib.php
@@ -66,6 +66,7 @@ class startdatedelay extends base_automatic {
 
     public function extend_add_instance_form_definition($mform) {
         $mform->addElement('duration', 'delay', get_string('delay', 'lifecycletrigger_startdatedelay'));
+        $mform->addHelpButton('delay', 'delay', 'lifecycletrigger_startdatedelay');
     }
 
     public function extend_add_instance_form_definition_after_data($mform, $settings) {


### PR DESCRIPTION
This commit gives help texts and help icons next to the labels.
Note that the labels have to be edited in the lang files. As of now, they just replicate the label text which is pretty useless.