### PR TITLE
Bugfix: Delete settings when a workflow gets deleted

### DIFF
--- a/classes/manager/step_manager.php
+++ b/classes/manager/step_manager.php
@@ -270,6 +270,10 @@ class step_manager extends subplugin_manager {
      */
     public static function remove_instances_of_workflow($workflowid) {
         global $DB;
+        $instances = self::get_step_instances($workflowid);
+        foreach ($instances as $instance) {
+            settings_manager::remove_settings($instance->id, SETTINGS_TYPE_STEP);
+        }
         $DB->delete_records('tool_lifecycle_step', array('workflowid' => $workflowid));
     }
 

--- a/classes/manager/trigger_manager.php
+++ b/classes/manager/trigger_manager.php
@@ -168,6 +168,8 @@ class trigger_manager extends subplugin_manager {
      */
     public static function remove_instances_of_workflow($workflowid) {
         global $DB;
+        $trigger = self::get_trigger_for_workflow($workflowid);
+        settings_manager::remove_settings($trigger->id, SETTINGS_TYPE_TRIGGER);
         $DB->delete_records('tool_lifecycle_trigger', array('workflowid' => $workflowid));
     }
 


### PR DESCRIPTION
Bug discovered by University of Würzburg.

When a workflow was deleted, the settings for the corresponding trigger and the corresponding steps weren't deleted and stayed orphaned in the database. This fix deletes the settings of the trigger and the steps too, when their workflow is deleted.