### PR TITLE
Improved processing of triggers for huge course amounts

### DIFF
--- a/classes/manager/delayed_courses_manager.php
+++ b/classes/manager/delayed_courses_manager.php
@@ -66,6 +66,16 @@ class delayed_courses_manager {
     }
 
     /**
+     * Build where sql for the processor to select only delayed courses.
+     * @return array
+     */
+    public static function get_course_delayed_wheresql() {
+        $where = "{course}.id IN (SELECT courseid FROM {tool_lifecycle_delayed} WHERE delayeduntil > :now)";
+        $params = array("now" => time());
+        return array($where, $params);
+    }
+
+    /**
      * Deletes the delay entry for a course.
      * @param int $courseid id of the course
      */

--- a/classes/processor.php
+++ b/classes/processor.php
@@ -79,6 +79,7 @@ class processor {
                 // If all trigger instances agree, that they want to trigger a process, we do so.
                 process_manager::create_process($course->id, $workflow->id);
                 $counttriggered++;
+                $recordset->next();
             }
             mtrace("   $countcourses courses processed.");
             mtrace("   $counttriggered courses triggered.");

--- a/classes/processor.php
+++ b/classes/processor.php
@@ -186,7 +186,7 @@ class processor {
         $sql = 'SELECT {course}.* from {course} '.
             'left join {tool_lifecycle_process} '.
             'ON {course}.id = {tool_lifecycle_process}.courseid '.
-            'WHERE {tool_lifecycle_process}.courseid is null ' . $where;
+            'WHERE {tool_lifecycle_process}.courseid is null AND ' . $where;
         return $DB->get_recordset_sql($sql, $whereparams);
     }
 

--- a/classes/processor.php
+++ b/classes/processor.php
@@ -188,7 +188,7 @@ class processor {
 
         if (!empty($exclude)) {
             list($insql, $inparams) = $DB->get_in_or_equal($exclude, SQL_PARAMS_NAMED);
-            $where .= " AND {course}.id {$insql}";
+            $where .= " AND NOT {course}.id {$insql}";
             $whereparams = array_merge($whereparams, $inparams);
         }
 

--- a/classes/processor.php
+++ b/classes/processor.php
@@ -188,7 +188,7 @@ class processor {
 
         if (!empty($exclude)) {
             list($insql, $inparams) = $DB->get_in_or_equal($exclude, SQL_PARAMS_NAMED);
-            $where .= "AND {$insql}";
+            $where .= " AND {course}.id {$insql}";
             $whereparams = array_merge($whereparams, $inparams);
         }
 

--- a/classes/processor.php
+++ b/classes/processor.php
@@ -173,7 +173,7 @@ class processor {
      * @params $exclude int[] list of course id, which should be excluded from execution.
      * @return \moodle_recordset with relevant courses.
      */
-    private function get_course_recordset($triggers, $exclude) {
+    public function get_course_recordset($triggers, $exclude) {
         global $DB;
 
         $where = 'true';

--- a/classes/processor.php
+++ b/classes/processor.php
@@ -47,28 +47,33 @@ class processor {
      */
     public function call_trigger() {
         $activeworkflows = workflow_manager::get_active_automatic_workflows();
+        $exclude = array();
 
-        $recordset = $this->get_course_recordset();
-        while ($recordset->valid()) {
-            $course = $recordset->current();
-            foreach ($activeworkflows as $workflow) {
-                $triggers = trigger_manager::get_triggers_for_workflow($workflow->id);
+        foreach ($activeworkflows as $workflow) {
+            mtrace('Calling triggers for workflow "' . $workflow->title . '"');
+            $triggers = trigger_manager::get_triggers_for_workflow($workflow->id);
+            $recordset = $this->get_course_recordset($triggers, $exclude);
+            while ($recordset->valid()) {
+                $course = $recordset->current();
                 foreach ($triggers as $trigger) {
                     $lib = lib_manager::get_automatic_trigger_lib($trigger->subpluginname);
                     $response = $lib->check_course($course, $trigger->id);
                     if ($response == trigger_response::next()) {
+                        $recordset->next();
                         continue 2;
                     }
                     if ($response == trigger_response::exclude()) {
-                        break 2;
+                        array_push($exclude, $course->id);
+                        $recordset->next();
+                        continue 2;
                     }
                     if ($response == trigger_response::trigger()) {
-                        process_manager::create_process($course->id, $trigger->workflowid);
                         continue;
                     }
                 }
+                // If all trigger instances agree, that they want to trigger a process, we do so.
+                process_manager::create_process($course->id, $workflow->id);
             }
-            $recordset->next();
         }
     }
 
@@ -154,15 +159,35 @@ class processor {
     /**
      * Returns a record set with all relevant courses.
      * Relevant means that there is currently no lifecycle process running for this course.
+     * @params $triggers trigger[] list of triggers, which will be asked for additional where requirements.
+     * @params $exclude int[] list of course id, which should be excluded from execution.
      * @return \moodle_recordset with relevant courses.
      */
-    private function get_course_recordset() {
+    private function get_course_recordset($triggers, $exclude) {
         global $DB;
+
+        $where = 'true';
+        $whereparams = array();
+        foreach ($triggers as $trigger) {
+            $lib = lib_manager::get_automatic_trigger_lib($trigger->subpluginname);
+            list($sql, $params) = $lib->get_course_recordset_where($trigger->id);
+            if (!empty($sql)) {
+                $where .= ' AND ' . $sql;
+                $whereparams = array_merge($whereparams, $params);
+            }
+        }
+
+        if (!empty($exclude)) {
+            list($insql, $inparams) = $DB->get_in_or_equal($exclude, SQL_PARAMS_NAMED);
+            $where .= "AND {$insql}";
+            $whereparams = array_merge($whereparams, $inparams);
+        }
+
         $sql = 'SELECT {course}.* from {course} '.
             'left join {tool_lifecycle_process} '.
             'ON {course}.id = {tool_lifecycle_process}.courseid '.
-            'WHERE {tool_lifecycle_process}.courseid is null';
-        return $DB->get_recordset_sql($sql);
+            'WHERE {tool_lifecycle_process}.courseid is null ' . $where;
+        return $DB->get_recordset_sql($sql, $whereparams);
     }
 
 }

--- a/step/email/lib.php
+++ b/step/email/lib.php
@@ -89,10 +89,12 @@ class email extends libbase {
     }
 
     public function post_processing_bulk_operation() {
-        global $DB;
+        global $DB, $PAGE;
         $stepinstances = step_manager::get_step_instances_by_subpluginname($this->get_subpluginname());
         foreach ($stepinstances as $step) {
             $settings = settings_manager::get_settings($step->id, SETTINGS_TYPE_STEP);
+            // Set system context, since format_text needs a context.
+            $PAGE->set_context(\context_system::instance());
             // Format the raw string in the DB to FORMAT_HTML.
             $settings['contenthtml'] = format_text($settings['contenthtml'], FORMAT_HTML);
 

--- a/trigger/categories/lib.php
+++ b/trigger/categories/lib.php
@@ -55,6 +55,7 @@ class categories extends base_automatic {
         $categories = settings_manager::get_settings($triggerid, SETTINGS_TYPE_TRIGGER)['categories'];
         $exclude = settings_manager::get_settings($triggerid, SETTINGS_TYPE_TRIGGER)['exclude'] && true;
 
+        $categories = explode(',', $categories);
         require_once($CFG->libdir . '/coursecatlib.php');
         $categoryobjects = coursecat::get_many($categories);
         $allcategories = array();

--- a/trigger/categories/tests/trigger_test.php
+++ b/trigger/categories/tests/trigger_test.php
@@ -41,7 +41,7 @@ class tool_lifecycle_trigger_categories_testcase extends \advanced_testcase {
     private $category;
     private $childcategory;
 
-    /**@var processor*/
+    /**@var processor Instance of the lifecycle processor */
     private $processor;
 
     public function setUp() {
@@ -73,15 +73,15 @@ class tool_lifecycle_trigger_categories_testcase extends \advanced_testcase {
 
         $course = $this->getDataGenerator()->create_course(array('category' => $this->category->id));
 
-        $recordset = $this->processor->get_course_recordset([$this->excludetrigger],[]);
+        $recordset = $this->processor->get_course_recordset([$this->excludetrigger], []);
         foreach ($recordset as $element) {
             $this->assertNotEquals($course->id, $element->id, 'The course should have been excluded by the trigger');
         }
         $recordset->close();
-        $recordset = $this->processor->get_course_recordset([$this->includetrigger],[]);
+        $recordset = $this->processor->get_course_recordset([$this->includetrigger], []);
         $found = false;
         foreach ($recordset as $element) {
-            if ($course->id === $element->id){
+            if ($course->id === $element->id) {
                 $found = true;
                 break;
             }
@@ -97,15 +97,15 @@ class tool_lifecycle_trigger_categories_testcase extends \advanced_testcase {
 
         $course = $this->getDataGenerator()->create_course(array('category' => $this->childcategory->id));
 
-        $recordset = $this->processor->get_course_recordset([$this->excludetrigger],[]);
+        $recordset = $this->processor->get_course_recordset([$this->excludetrigger], []);
         foreach ($recordset as $element) {
             $this->assertNotEquals($course->id, $element->id, 'The course should have been excluded by the trigger');
         }
         $recordset->close();
-        $recordset = $this->processor->get_course_recordset([$this->includetrigger],[]);
+        $recordset = $this->processor->get_course_recordset([$this->includetrigger], []);
         $found = false;
         foreach ($recordset as $element) {
-            if ($course->id === $element->id){
+            if ($course->id === $element->id) {
                 $found = true;
                 break;
             }
@@ -120,15 +120,15 @@ class tool_lifecycle_trigger_categories_testcase extends \advanced_testcase {
     public function test_course_not_within_cat() {
         $course = $this->getDataGenerator()->create_course();
 
-        $recordset = $this->processor->get_course_recordset([$this->includetrigger],[]);
+        $recordset = $this->processor->get_course_recordset([$this->includetrigger], []);
         foreach ($recordset as $element) {
             $this->assertNotEquals($course->id, $element->id, 'The course should have been excluded by the trigger');
         }
         $recordset->close();
-        $recordset = $this->processor->get_course_recordset([$this->excludetrigger],[]);
+        $recordset = $this->processor->get_course_recordset([$this->excludetrigger], []);
         $found = false;
         foreach ($recordset as $element) {
-            if ($course->id === $element->id){
+            if ($course->id === $element->id) {
                 $found = true;
                 break;
             }

--- a/trigger/delayedcourses/lib.php
+++ b/trigger/delayedcourses/lib.php
@@ -44,11 +44,11 @@ class delayedcourses extends base_automatic {
      * @return trigger_response
      */
     public function check_course($course, $triggerid) {
-        $delayeduntil = delayed_courses_manager::get_course_delayed($course->id);
-        if ($delayeduntil !== null && time() < $delayeduntil) {
-            return trigger_response::exclude();
-        }
-        return trigger_response::next();
+        return trigger_response::exclude();
+    }
+
+    public function get_course_recordset_where($triggerid) {
+        return delayed_courses_manager::get_course_delayed_wheresql();
     }
 
     public function get_subpluginname() {

--- a/trigger/delayedcourses/tests/trigger_test.php
+++ b/trigger/delayedcourses/tests/trigger_test.php
@@ -38,7 +38,7 @@ class tool_lifecycle_trigger_delayedcourses_testcase extends \advanced_testcase 
 
     private $triggerinstance;
 
-    /** @var processor */
+    /**@var processor Instance of the lifecycle processor */
     private $processor;
 
     public function setUp() {
@@ -63,6 +63,7 @@ class tool_lifecycle_trigger_delayedcourses_testcase extends \advanced_testcase 
                 $found = true;
             }
         }
+        $recordset->close();
         $this->assertFalse($found, 'The course should not have passed through since it should not be delay');
     }
 
@@ -82,6 +83,7 @@ class tool_lifecycle_trigger_delayedcourses_testcase extends \advanced_testcase 
                 $found = true;
             }
         }
+        $recordset->close();
         $this->assertTrue($found, 'The course should not have passed through in order to delay it');
     }
 
@@ -101,6 +103,7 @@ class tool_lifecycle_trigger_delayedcourses_testcase extends \advanced_testcase 
                 $found = true;
             }
         }
+        $recordset->close();
         $this->assertFalse($found, 'The course should not have passed through since it should not be delay');
     }
 }

--- a/trigger/delayedcourses/tests/trigger_test.php
+++ b/trigger/delayedcourses/tests/trigger_test.php
@@ -16,6 +16,7 @@
 
 namespace tool_lifecycle\trigger;
 
+use tool_lifecycle\processor;
 use tool_lifecycle\response\trigger_response;
 use tool_lifecycle\manager\delayed_courses_manager;
 
@@ -37,10 +38,14 @@ class tool_lifecycle_trigger_delayedcourses_testcase extends \advanced_testcase 
 
     private $triggerinstance;
 
+    /** @var processor */
+    private $processor;
+
     public function setUp() {
         $this->resetAfterTest(true);
         $this->setAdminUser();
 
+        $this->processor = new processor();
         $this->triggerinstance = \tool_lifecycle_trigger_delayedcourses_generator::create_trigger_with_workflow();
     }
 
@@ -51,9 +56,14 @@ class tool_lifecycle_trigger_delayedcourses_testcase extends \advanced_testcase 
 
         $course = $this->getDataGenerator()->create_course();
 
-        $trigger = new delayedcourses();
-        $response = $trigger->check_course($course, $this->triggerinstance->id);
-        $this->assertEquals($response, trigger_response::next());
+        $recordset = $this->processor->get_course_recordset([$this->triggerinstance], []);
+        $found = false;
+        foreach ($recordset as $element) {
+            if ($course->id == $element->id) {
+                $found = true;
+            }
+        }
+        $this->assertFalse($found, 'The course should not have passed through since it should not be delay');
     }
 
     /**
@@ -65,9 +75,14 @@ class tool_lifecycle_trigger_delayedcourses_testcase extends \advanced_testcase 
 
         delayed_courses_manager::set_course_delayed($course->id, 2000);
 
-        $trigger = new delayedcourses();
-        $response = $trigger->check_course($course, $this->triggerinstance->id);
-        $this->assertEquals($response, trigger_response::exclude());
+        $recordset = $this->processor->get_course_recordset([$this->triggerinstance], []);
+        $found = false;
+        foreach ($recordset as $element) {
+            if ($course->id == $element->id) {
+                $found = true;
+            }
+        }
+        $this->assertTrue($found, 'The course should not have passed through in order to delay it');
     }
 
     /**
@@ -79,8 +94,13 @@ class tool_lifecycle_trigger_delayedcourses_testcase extends \advanced_testcase 
 
         delayed_courses_manager::set_course_delayed($course->id, -2000);
 
-        $trigger = new delayedcourses();
-        $response = $trigger->check_course($course, $this->triggerinstance->id);
-        $this->assertEquals($response, trigger_response::next());
+        $recordset = $this->processor->get_course_recordset([$this->triggerinstance], []);
+        $found = false;
+        foreach ($recordset as $element) {
+            if ($course->id == $element->id) {
+                $found = true;
+            }
+        }
+        $this->assertFalse($found, 'The course should not have passed through since it should not be delay');
     }
 }

--- a/trigger/lib.php
+++ b/trigger/lib.php
@@ -120,6 +120,17 @@ abstract class base_automatic extends base {
     public function is_manual_trigger() {
         return false;
     }
+
+    /**
+     * Allows to return a where clause, which reduces the recordset of relevant courses.
+     * The return value has to consist of an array with two values. The first one includes the where sql statement,
+     * which will be concatenated using an 'AND' to the recordset query (e.g. 'course.id = $courseid').
+     * The second one is the set of parameters for the sql query, which will be merged with other param sets.
+     * @params $triggerid int id of the trigger.
+     */
+    public function get_course_recordset_where($triggerid) {
+        return array('', array());
+    }
 }
 
 /**

--- a/trigger/sitecourse/lib.php
+++ b/trigger/sitecourse/lib.php
@@ -35,7 +35,6 @@ require_once(__DIR__ . '/../lib.php');
  */
 class sitecourse extends base_automatic {
 
-
     /**
      * Checks the course and returns a repsonse, which tells if the course should be further processed.
      * @param $course object to be processed.
@@ -47,6 +46,12 @@ class sitecourse extends base_automatic {
             return trigger_response::exclude();
         }
         return trigger_response::next();
+    }
+
+    public function get_course_recordset_where($triggerid) {
+        global $DB;
+        list($insql, $inparam) = $DB->get_in_or_equal(SITEID, SQL_PARAMS_NAMED);
+        return array("{course}.id {$insql}", $inparam);
     }
 
     public function get_subpluginname() {

--- a/trigger/specificdate/lib.php
+++ b/trigger/specificdate/lib.php
@@ -90,7 +90,7 @@ class specificdate extends base_automatic {
         return array('false', array());
     }
 
-        /**
+    /**
      * Parses the dates settings to actual date objects.
      * @param $datesraw string
      */

--- a/trigger/specificdate/lib.php
+++ b/trigger/specificdate/lib.php
@@ -40,8 +40,6 @@ require_once(__DIR__ . '/../../lib.php');
  */
 class specificdate extends base_automatic {
 
-    private $alreadychecked = array();
-
     /**
      * Checks the course and returns a repsonse, which tells if the course should be further processed.
      * @param $course object to be processed.
@@ -49,50 +47,50 @@ class specificdate extends base_automatic {
      * @return trigger_response
      */
     public function check_course($course, $triggerid) {
-        if (!array_key_exists($triggerid, $this->alreadychecked)) {
-            $settings = settings_manager::get_settings($triggerid, SETTINGS_TYPE_TRIGGER);
-            $lastrun = getdate($settings['timelastrun']);
-            $datesraw = $settings['dates'];
-            $dates = $this->parse_dates($datesraw);
-
-            $triggerat = array();
-
-            foreach ($dates as $date) {
-                if ($date['mon'] > $lastrun['mon']) {
-                    $date = new DateTime($lastrun['year'].'-'.$date['mon'].'-'.$date['day']);
-                }
-                if ($date['mon'] === $lastrun['mon']) {
-                    if ($date['day'] > $lastrun['day']) {
-                        $date = new DateTime($lastrun['year'].'-'.$date['mon'].'-'.$date['day']);
-                    } else {
-                        $date = new DateTime(($lastrun['year'] + 1) .'-'.$date['mon'].'-'.$date['day']);
-                    }
-                } else {
-                    $date = new DateTime(($lastrun['year'] + 1) .'-'.$date['mon'].'-'.$date['day']);
-                }
-
-                $triggerat [] = $date->getTimestamp();
-            }
-
-            sort($triggerat);
-
-            $current = time();
-
-            foreach ($triggerat as $timestamp) {
-                if ($timestamp < $current) {
-                    $this->alreadychecked[$triggerid] = trigger_response::trigger();
-                    $settings['timelastrun'] = $current;
-                    $trigger = trigger_manager::get_instance($triggerid);
-                    settings_manager::save_settings($triggerid, SETTINGS_TYPE_TRIGGER, $trigger->subpluginname, $settings);
-                    return $this->alreadychecked[$triggerid];
-                }
-            }
-            $this->alreadychecked[$triggerid] = trigger_response::next();
-        }
-        return $this->alreadychecked[$triggerid];
+        // Everything is already in the sql statement.
+        return trigger_response::trigger();
     }
 
-    /**
+    public function get_course_recordset_where($triggerid) {
+        $settings = settings_manager::get_settings($triggerid, SETTINGS_TYPE_TRIGGER);
+        $lastrun = getdate($settings['timelastrun']);
+        $datesraw = $settings['dates'];
+        $dates = $this->parse_dates($datesraw);
+
+        $triggerat = array();
+
+        foreach ($dates as $dateparts) {
+            if ($dateparts['mon'] > $lastrun['mon']) {
+                $date = new DateTime($lastrun['year'].'-'.$dateparts['mon'].'-'.$dateparts['day']);
+            } else if ($dateparts['mon'] === $lastrun['mon']) {
+                if ($dateparts['day'] > $lastrun['day']) {
+                    $date = new DateTime($lastrun['year'].'-'.$dateparts['mon'].'-'.$dateparts['day']);
+                } else {
+                    $date = new DateTime(($lastrun['year'] + 1) .'-'.$dateparts['mon'].'-'.$dateparts['day']);
+                }
+            } else {
+                $date = new DateTime(($lastrun['year'] + 1) .'-'.$dateparts['mon'].'-'.$dateparts['day']);
+            }
+
+            $triggerat [] = $date->getTimestamp();
+        }
+
+        sort($triggerat);
+
+        $current = time();
+
+        foreach ($triggerat as $timestamp) {
+            if ($timestamp < $current) {
+                $settings['timelastrun'] = $current;
+                $trigger = trigger_manager::get_instance($triggerid);
+                settings_manager::save_settings($triggerid, SETTINGS_TYPE_TRIGGER, $trigger->subpluginname, $settings);
+                return array('true', array());
+            }
+        }
+        return array('false', array());
+    }
+
+        /**
      * Parses the dates settings to actual date objects.
      * @param $datesraw string
      */

--- a/trigger/startdatedelay/lib.php
+++ b/trigger/startdatedelay/lib.php
@@ -46,12 +46,17 @@ class startdatedelay extends base_automatic {
      * @return trigger_response
      */
     public function check_course($course, $triggerid) {
+        // Everything is already in the sql statement.
+        return trigger_response::trigger();
+    }
+
+    public function get_course_recordset_where($triggerid) {
         $delay = settings_manager::get_settings($triggerid, SETTINGS_TYPE_TRIGGER)['delay'];
-        $now = time();
-        if ($course->startdate + $delay < $now) {
-            return trigger_response::trigger();
-        }
-        return trigger_response::next();
+        $where = "{course}.startdate < :startdatedelay";
+        $params = array(
+            "startdatedelay" => time() - $delay,
+        );
+        return array($where, $params);
     }
 
     public function get_subpluginname() {


### PR DESCRIPTION
For huge amounts of courses, the trigger processing is currently very slow.
This PR introduces a new function for trigger, in which they can extend the where sql statement of the course recordset, which is constructed before actually calling the call_trigger() function of each trigger.