### PR TITLE
New trigger: "categorytrigger", triggers for courses in specific category 

### DIFF
--- a/trigger/category/lang/en/lifecycletrigger_category.php
+++ b/trigger/category/lang/en/lifecycletrigger_category.php
@@ -1,0 +1,28 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Lang strings for category trigger
+ *
+ * @package tool_lifecycle_trigger
+ * @subpackage category
+ * @copyright  2019 Yorick Reum JMU
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+$string['pluginname'] = 'Category trigger';
+$string['category_select'] = 'Category';
+$string['category_select_help'] = 'Select the category whose courses should be triggered.';

--- a/trigger/category/lib.php
+++ b/trigger/category/lib.php
@@ -68,11 +68,12 @@ class category extends base_automatic {
         global $DB;
         $elementname = 'category_select';
         $categories = $DB->get_records('course_categories');
-        $categoriesToShow = array();
+        $categoriestoshow = array();
         foreach ($categories as $category) {
-            $categoriesToShow[$category->id] = $category->name;
+            $categoriestoshow[$category->id] = $category->name;
         }
-        $mform->addElement('select', $elementname, get_string($elementname, 'lifecycletrigger_category'), $categoriesToShow);
+
+        $mform->addElement('select', $elementname, get_string($elementname, 'lifecycletrigger_category'), $categoriestoshow);
         $mform->addHelpButton($elementname, $elementname, 'lifecycletrigger_category');
     }
 

--- a/trigger/category/lib.php
+++ b/trigger/category/lib.php
@@ -1,0 +1,79 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Interface for the subplugintype trigger
+ * It has to be implemented by all subplugins.
+ *
+ * @package tool_lifecycle_trigger
+ * @subpackage category
+ * @copyright  2019 Yorick Reum JMU
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace tool_lifecycle\trigger;
+
+use tool_lifecycle\manager\settings_manager;
+use tool_lifecycle\response\trigger_response;
+
+defined('MOODLE_INTERNAL') || die();
+require_once(__DIR__ . '/../lib.php');
+
+/**
+ * Class which implements the basic methods necessary for a cleanyp courses trigger subplugin
+ *
+ * @package tool_lifecycle_trigger
+ */
+class category extends base_automatic {
+
+    /**
+     * Checks the course and returns a repsonse, which tells if the course should be further processed.
+     *
+     * @param $course object to be processed.
+     * @param $triggerid int id of the trigger instance.
+     * @return trigger_response
+     */
+    public function check_course($course, $triggerid) {
+        $settings = settings_manager::get_settings($triggerid, SETTINGS_TYPE_TRIGGER);
+        if ($course->category == $settings['category_select']) {
+            return trigger_response::trigger();
+        }
+        return trigger_response::next();
+    }
+
+    public function get_subpluginname() {
+        return 'category';
+    }
+
+    public function instance_settings() {
+        return array(
+            new instance_setting('category_select', PARAM_INT)
+        );
+    }
+
+    public function extend_add_instance_form_definition($mform) {
+        global $DB;
+        $elementname = 'category_select';
+        $categories = $DB->get_records('course_categories');
+        $categoriesToShow = array();
+        foreach ($categories as $category) {
+            $categoriesToShow[$category->id] = $category->name;
+        }
+        $mform->addElement('select', $elementname, get_string($elementname, 'lifecycletrigger_category'), $categoriesToShow);
+        $mform->addHelpButton($elementname, $elementname, 'lifecycletrigger_category');
+    }
+
+}

--- a/trigger/category/tests/generator/lib.php
+++ b/trigger/category/tests/generator/lib.php
@@ -1,0 +1,63 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+defined('MOODLE_INTERNAL') || die();
+
+use tool_lifecycle\entity\trigger_subplugin;
+use tool_lifecycle\entity\workflow;
+use tool_lifecycle\manager\settings_manager;
+use tool_lifecycle\manager\trigger_manager;
+use tool_lifecycle\manager\workflow_manager;
+
+/**
+ * lifecycletrigger_category generator tests
+ *
+ * @package    lifecycletrigger_category
+ * @category   test
+ * @copyright  2019 Yorick Reum JMU
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class tool_lifecycle_trigger_category_generator extends testing_module_generator {
+
+    /**
+     * Creates a trigger category for an artificial workflow without steps.
+     *
+     * @param $categoryid int category id to set the trigger to
+     * @return trigger_subplugin the created category trigger.
+     * @throws moodle_exception
+     */
+    public static function create_trigger_with_workflow($categoryid) {
+        // Create Workflow.
+        $record = new stdClass();
+        $record->id = null;
+        $record->title = 'myworkflow';
+        $workflow = workflow::from_record($record);
+        workflow_manager::insert_or_update($workflow);
+        // Create trigger.
+        $record = new stdClass();
+        $record->subpluginname = 'category';
+        $record->instancename = 'category';
+        $record->workflowid = $workflow->id;
+        $trigger = trigger_subplugin::from_record($record);
+        trigger_manager::insert_or_update($trigger);
+        // Set category setting.
+        $settings = new stdClass();
+        $settings->category_select = $categoryid;
+        settings_manager::save_settings($trigger->id, SETTINGS_TYPE_TRIGGER, $trigger->subpluginname, $settings);
+
+        return $trigger;
+    }
+}

--- a/trigger/category/tests/trigger_test.php
+++ b/trigger/category/tests/trigger_test.php
@@ -1,0 +1,89 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_lifecycle\trigger;
+
+use tool_lifecycle\response\trigger_response;
+use core_course_category;
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once(__DIR__ . '/../lib.php');
+require_once(__DIR__ . '/generator/lib.php');
+
+
+/**
+ * Trigger test for start date delay trigger.
+ *
+ * @package    tool_lifecycle_trigger
+ * @category   category
+ * @group tool_lifecycle_trigger
+ * @copyright  2019 Yorick Reum JMU
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class tool_lifecycle_trigger_category_testcase extends \advanced_testcase {
+
+    private $triggerinstance;
+    private $category1;
+    private $category2;
+
+    public function setUp() {
+        $this->resetAfterTest(true);
+        $this->setAdminUser();
+
+        $data = new \stdClass();
+
+        $data->name = 'my category 1';
+        $data->description = 'my category 1 description';
+        $data->idnumber = '';
+        $this->category1 = core_course_category::create($data);
+
+        $data->name = 'my category 2';
+        $data->description = 'my category 2 description';
+        $data->idnumber = '';
+        $this->category2 = core_course_category::create($data);
+
+        $this->triggerinstance = \tool_lifecycle_trigger_category_generator::create_trigger_with_workflow($this->category1->id);
+    }
+
+    /**
+     * Tests if courses, which are not in the test category are not triggered by this plugin.
+     */
+    public function test_wrong_category_course() {
+
+        $course = $this->getDataGenerator()->create_course(array('category' => $this->category2->id));
+
+        $trigger = new category();
+        $response = $trigger->check_course($course, $this->triggerinstance->id);
+        $this->assertEquals($response, trigger_response::next());
+
+//        $this->assertTrue(false);
+
+    }
+
+    /**
+     * Tests if courses, which are in the test category are triggered by this plugin.
+     */
+    public function test_right_category_course() {
+
+        $course = $this->getDataGenerator()->create_course(array('category' => $this->category1->id));
+
+        $trigger = new category();
+        $response = $trigger->check_course($course, $this->triggerinstance->id);
+        $this->assertEquals($response, trigger_response::trigger());
+
+    }
+}

--- a/trigger/category/tests/trigger_test.php
+++ b/trigger/category/tests/trigger_test.php
@@ -63,27 +63,21 @@ class tool_lifecycle_trigger_category_testcase extends \advanced_testcase {
      * Tests if courses, which are not in the test category are not triggered by this plugin.
      */
     public function test_wrong_category_course() {
-
         $course = $this->getDataGenerator()->create_course(array('category' => $this->category2->id));
 
         $trigger = new category();
         $response = $trigger->check_course($course, $this->triggerinstance->id);
         $this->assertEquals($response, trigger_response::next());
-
-//        $this->assertTrue(false);
-
     }
 
     /**
      * Tests if courses, which are in the test category are triggered by this plugin.
      */
     public function test_right_category_course() {
-
         $course = $this->getDataGenerator()->create_course(array('category' => $this->category1->id));
 
         $trigger = new category();
         $response = $trigger->check_course($course, $this->triggerinstance->id);
         $this->assertEquals($response, trigger_response::trigger());
-
     }
 }

--- a/trigger/category/tests/trigger_test.php
+++ b/trigger/category/tests/trigger_test.php
@@ -15,11 +15,10 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace tool_lifecycle\trigger;
-
-use tool_lifecycle\response\trigger_response;
-use core_course_category;
-
 defined('MOODLE_INTERNAL') || die();
+
+use core_course_category;
+use tool_lifecycle\response\trigger_response;
 
 require_once(__DIR__ . '/../lib.php');
 require_once(__DIR__ . '/generator/lib.php');

--- a/trigger/category/tests/trigger_test.php
+++ b/trigger/category/tests/trigger_test.php
@@ -17,8 +17,8 @@
 namespace tool_lifecycle\trigger;
 defined('MOODLE_INTERNAL') || die();
 
-use core_course_category;
 use tool_lifecycle\response\trigger_response;
+use core_course_category;
 
 require_once(__DIR__ . '/../lib.php');
 require_once(__DIR__ . '/generator/lib.php');
@@ -40,6 +40,7 @@ class tool_lifecycle_trigger_category_testcase extends \advanced_testcase {
     private $category2;
 
     public function setUp() {
+        global $CFG;
         $this->resetAfterTest(true);
         $this->setAdminUser();
 
@@ -48,12 +49,21 @@ class tool_lifecycle_trigger_category_testcase extends \advanced_testcase {
         $data->name = 'my category 1';
         $data->description = 'my category 1 description';
         $data->idnumber = '';
-        $this->category1 = core_course_category::create($data);
+        if ($CFG->version >= 2018120300) { // Since Moodle 3.6
+            $this->category1 = core_course_category::create($data);
+        } else { // Before Moodle 3.6
+            require_once($CFG->libdir . '/coursecatlib.php');
+            $this->category1 = coursecat::create($data);
+        }
 
         $data->name = 'my category 2';
         $data->description = 'my category 2 description';
         $data->idnumber = '';
-        $this->category2 = core_course_category::create($data);
+        if ($CFG->version >= 2018120300) { // Since Moodle 3.6
+            $this->category2 = core_course_category::create($data);
+        } else { // Before Moodle 3.6
+            $this->category2 = core_course_category::create($data);
+        }
 
         $this->triggerinstance = \tool_lifecycle_trigger_category_generator::create_trigger_with_workflow($this->category1->id);
     }

--- a/trigger/category/tests/trigger_test.php
+++ b/trigger/category/tests/trigger_test.php
@@ -53,7 +53,7 @@ class tool_lifecycle_trigger_category_testcase extends \advanced_testcase {
             $this->category1 = core_course_category::create($data);
         } else { // Before Moodle 3.6
             require_once($CFG->libdir . '/coursecatlib.php');
-            $this->category1 = coursecat::create($data);
+            $this->category1 = \coursecat::create($data);
         }
 
         $data->name = 'my category 2';
@@ -62,7 +62,7 @@ class tool_lifecycle_trigger_category_testcase extends \advanced_testcase {
         if ($CFG->version >= 2018120300) { // Since Moodle 3.6
             $this->category2 = core_course_category::create($data);
         } else { // Before Moodle 3.6
-            $this->category2 = core_course_category::create($data);
+            $this->category2 = \coursecat::create($data);
         }
 
         $this->triggerinstance = \tool_lifecycle_trigger_category_generator::create_trigger_with_workflow($this->category1->id);

--- a/trigger/category/version.php
+++ b/trigger/category/version.php
@@ -1,0 +1,29 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Life Cycle Category Trigger
+ *
+ * @package tool_lifecycle_trigger
+ * @subpackage category
+ * @copyright  2019 Yorick Reum JMU
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die;
+
+$plugin->version  = 2017050901;
+$plugin->component = 'lifecycletrigger_category';


### PR DESCRIPTION
Here at the University of Würzburg, we put all courses of one term/semester into a certain category (like a lot of other german universities do). Hence, it's useful for us to be able to trigger specific (older) categories by just selecting them; no need to think about the start or end dates of the courses as we had to when using the "start date delay" trigger.

More concrete, in our specific use case, we are willing to use this together with our new "move category" step to move older courses to an invisible category before deleting them.

While testing the trigger with Travis, we recognised there was some trouble with older versions of Moodle (< 3.6). To support them, we added a version checking conditional statement to the code. Now the trigger is working from Moodle version 3.3 to current 3.6, but the code is a little longer / more complex.

At them moment, Travis is only set to check Moodle versions 3.3 and 3.4, but we tested it locally and with some changes the the travis settings file in our fork. When updating travis.xml to newer moodle versions, the java dependency and postgresql need to be updated / set to newer versions. Also, some of the current Behat tests/syntax got deprecated.