### PR TITLE
Add a configuration to limit the number of courses deleted per cron

### DIFF
--- a/step/deletecourse/db/upgrade.php
+++ b/step/deletecourse/db/upgrade.php
@@ -1,0 +1,50 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Update script for lifecycles subplugin deletecourse
+ *
+ * @package tool_lifecycle_step
+ * @subpackage deletecourse
+ * @copyright  2018 Tobias Reischmann WWU
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+use tool_lifecycle\manager\settings_manager;
+use tool_lifecycle\manager\step_manager;
+
+defined('MOODLE_INTERNAL') || die();
+
+function xmldb_lifecyclestep_deletecourse_upgrade($oldversion) {
+
+    if ($oldversion < 2018122300) {
+
+        $coursedeletesteps = step_manager::get_step_instances_by_subpluginname('deletecourse');
+
+        $settingsname = 'maximumdeletionspercron';
+        $settingsvalue = 10;
+        foreach ($coursedeletesteps as $step) {
+            if (empty(settings_manager::get_settings($step->id, 'step'))) {
+                settings_manager::save_settings($step->id, 'step', 'deletecourse',
+                    array($settingsname => $settingsvalue));
+            }
+        }
+
+        // Deletecourse savepoint reached.
+        upgrade_plugin_savepoint(true, 2018122300, 'lifecyclestep', 'deletecourse');
+    }
+
+}

--- a/step/deletecourse/lang/en/lifecyclestep_deletecourse.php
+++ b/step/deletecourse/lang/en/lifecyclestep_deletecourse.php
@@ -24,3 +24,5 @@
  */
 
 $string['pluginname'] = 'Delete Course Step';
+
+$string['deletecourse_maximumdeletionspercron'] = 'Maximum number of courses deleted per cron';

--- a/step/deletecourse/version.php
+++ b/step/deletecourse/version.php
@@ -25,5 +25,5 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version  = 2017050901;
+$plugin->version  = 2018122300;
 $plugin->component = 'lifecyclestep_deletecourse';


### PR DESCRIPTION
Currently, there is no limitation, how many courses might be deleted per cron job run. This might be quite a lot for huge platforms. Since a course deletion takes a lot of time, this patch allows to reduce the amount of courses, which can be deleted within one cron job run.