### PR TITLE
Enhanced "categories" trigger to use autocompletion for category selection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ addons:
   postgresql: "9.4"
   apt:
     packages:
-      - oracle-java8-installer
-      - oracle-java8-set-default
+      - oracle-java9-installer
+      - oracle-java9-set-default
 
 
 php:

--- a/classes/manager/settings_manager.php
+++ b/classes/manager/settings_manager.php
@@ -67,7 +67,11 @@ class settings_manager {
                     $value = $value['text'];
                 }
                 if (is_array($value)) {
-                    $cleanedvalue = clean_param_array($value, $setting->paramtype);
+                    // Not sure if this is best practice...
+                    $cleanedvalue = implode(
+                        ',',
+                        clean_param_array($value, $setting->paramtype)
+                    );
                 } else {
                     $cleanedvalue = clean_param($value, $setting->paramtype);
                 }

--- a/classes/manager/settings_manager.php
+++ b/classes/manager/settings_manager.php
@@ -66,7 +66,11 @@ class settings_manager {
                 if (is_array($value) && array_key_exists('text', $value)) {
                     $value = $value['text'];
                 }
-                $cleanedvalue = clean_param($value, $setting->paramtype);
+                if (is_array($value)) {
+                    $cleanedvalue = clean_param_array($value, $setting->paramtype);
+                } else {
+                    $cleanedvalue = clean_param($value, $setting->paramtype);
+                }
                 $record = $DB->get_record('tool_lifecycle_settings',
                     array(
                         'instanceid' => $instanceid,

--- a/trigger/categories/lang/en/lifecycletrigger_categories.php
+++ b/trigger/categories/lang/en/lifecycletrigger_categories.php
@@ -25,5 +25,6 @@
 
 $string['pluginname'] = 'Categories trigger';
 
-$string['categories'] = 'IDs of categories for which the workflow should be triggered';
+$string['categories'] = 'Categories, for which the workflow should be triggered';
+$string['categories_noselection'] = 'Please choose at least one category.';
 $string['exclude'] = 'If ticked, the named categories are excluded from triggering instead.';

--- a/trigger/categories/lib.php
+++ b/trigger/categories/lib.php
@@ -81,7 +81,7 @@ class categories extends base_automatic {
 
     public function instance_settings() {
         return array(
-            new instance_setting('categories', PARAM_INT),
+            new instance_setting('categories', PARAM_SEQUENCE),
             new instance_setting('exclude', PARAM_BOOL),
         );
     }
@@ -95,10 +95,10 @@ class categories extends base_automatic {
         }
         $options = array(
             'multiple' => true,
-            'noselectionstring' => 'lol lol lol',
+            'noselectionstring' => get_string('categories_noselection', 'lifecycletrigger_categories'),
         );
         $mform->addElement('autocomplete', 'categories', get_string('categories', 'lifecycletrigger_categories'), $categorynames, $options);
-//        $mform->setType('categories', PARAM_INT);
+        $mform->setType('categories', PARAM_SEQUENCE);
 
         $mform->addElement('advcheckbox', 'exclude', get_string('exclude', 'lifecycletrigger_categories'));
         $mform->setType('exclude', PARAM_BOOL);

--- a/trigger/categories/lib.php
+++ b/trigger/categories/lib.php
@@ -81,14 +81,25 @@ class categories extends base_automatic {
 
     public function instance_settings() {
         return array(
-            new instance_setting('categories', PARAM_SEQUENCE),
+            new instance_setting('categories', PARAM_INT),
             new instance_setting('exclude', PARAM_BOOL),
         );
     }
 
     public function extend_add_instance_form_definition($mform) {
-        $mform->addElement('text', 'categories', get_string('categories', 'lifecycletrigger_categories'));
-        $mform->setType('categories', PARAM_SEQUENCE);
+        global $DB;
+        $categories = $DB->get_records('course_categories');
+        $categorynames = array();
+        foreach ($categories as $category) {
+            $categorynames[$category->id] = $category->name;
+        }
+        $options = array(
+            'multiple' => true,
+            'noselectionstring' => 'lol lol lol',
+        );
+        $mform->addElement('autocomplete', 'categories', get_string('categories', 'lifecycletrigger_categories'), $categorynames, $options);
+//        $mform->setType('categories', PARAM_INT);
+
         $mform->addElement('advcheckbox', 'exclude', get_string('exclude', 'lifecycletrigger_categories'));
         $mform->setType('exclude', PARAM_BOOL);
     }


### PR DESCRIPTION
Enhances "categories" trigger to use autocompletion for category selection instead of comma separated input of IDs for better usability.

For storing the array of IDs in database, I modified settings_manager to implode arrays. Not quite sure if this is the best way in all cases or if there is a better practice, but I think it's totally fine here.