### PR TITLE
Limit the number of backups per cron

### DIFF
--- a/step/createbackup/db/upgrade.php
+++ b/step/createbackup/db/upgrade.php
@@ -1,0 +1,50 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Update script for lifecycles subplugin deletecourse
+ *
+ * @package tool_lifecycle_step
+ * @subpackage createbackup
+ * @copyright  2019 WWU
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+use tool_lifecycle\manager\settings_manager;
+use tool_lifecycle\manager\step_manager;
+
+defined('MOODLE_INTERNAL') || die();
+
+function xmldb_lifecyclestep_createbackup_upgrade($oldversion) {
+
+    if ($oldversion < 2019052900) {
+
+        $coursedeletesteps = step_manager::get_step_instances_by_subpluginname('createbackup');
+
+        $settingsname = 'maximumbackupspercron';
+        $settingsvalue = 10;
+        foreach ($coursedeletesteps as $step) {
+            if (empty(settings_manager::get_settings($step->id, 'step'))) {
+                settings_manager::save_settings($step->id, 'step', 'createbackup',
+                    array($settingsname => $settingsvalue));
+            }
+        }
+
+        // Deletecourse savepoint reached.
+        upgrade_plugin_savepoint(true, 2019052900, 'lifecyclestep', 'createbackup');
+    }
+
+}

--- a/step/createbackup/lang/en/lifecyclestep_createbackup.php
+++ b/step/createbackup/lang/en/lifecyclestep_createbackup.php
@@ -24,3 +24,5 @@
  */
 
 $string['pluginname'] = 'Create Backup Step';
+
+$string['createbackup_maximumbackupspercron'] = 'Maximum number of Backups per cron';

--- a/step/createbackup/lang/en/lifecyclestep_createbackup.php
+++ b/step/createbackup/lang/en/lifecyclestep_createbackup.php
@@ -25,4 +25,4 @@
 
 $string['pluginname'] = 'Create Backup Step';
 
-$string['createbackup_maximumbackupspercron'] = 'Maximum number of Backups per cron';
+$string['maximumbackupspercron'] = 'Maximum number of Backups per cron';

--- a/step/createbackup/lib.php
+++ b/step/createbackup/lib.php
@@ -56,7 +56,6 @@ class createbackup extends libbase {
     public function process_course($processid, $instanceid, $course) {
         if (self::$numberofbackups >= settings_manager::get_settings(
                 $instanceid, SETTINGS_TYPE_STEP)['maximumbackupspercron']) {
-            mtrace('###################end backup because max');
             return step_response::waiting(); // Wait with further deletions til the next cron run.
         }
         if (backup_manager::create_course_backup($course->id)) {
@@ -82,7 +81,8 @@ class createbackup extends libbase {
     }
     public function extend_add_instance_form_definition($mform) {
         $elementname = 'maximumbackupspercron';
-        $mform->addElement('text', $elementname, get_string('createbackup_maximumbackupspercron', 'lifecyclestep_createbackup'));
+        $mform->addElement('text', $elementname,
+            get_string('createbackup_maximumbackupspercron', 'lifecyclestep_createbackup'));
         $mform->setType($elementname, PARAM_INT);
         $mform->setDefault($elementname, 10);
     }

--- a/step/createbackup/lib.php
+++ b/step/createbackup/lib.php
@@ -56,7 +56,7 @@ class createbackup extends libbase {
     public function process_course($processid, $instanceid, $course) {
         if (self::$numberofbackups >= settings_manager::get_settings(
                 $instanceid, SETTINGS_TYPE_STEP)['maximumbackupspercron']) {
-            return step_response::waiting(); // Wait with further deletions til the next cron run.
+            return step_response::waiting(); // Wait with further backups til the next cron run.
         }
         if (backup_manager::create_course_backup($course->id)) {
             self::$numberofbackups++;
@@ -82,7 +82,7 @@ class createbackup extends libbase {
     public function extend_add_instance_form_definition($mform) {
         $elementname = 'maximumbackupspercron';
         $mform->addElement('text', $elementname,
-            get_string('createbackup_maximumbackupspercron', 'lifecyclestep_createbackup'));
+            get_string('maximumbackupspercron', 'lifecyclestep_createbackup'));
         $mform->setType($elementname, PARAM_INT);
         $mform->setDefault($elementname, 10);
     }

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -45,7 +45,9 @@ class tool_lifecycle_generator extends testing_module_generator {
             "content" => "Content",
             "contenthtml" => "Content HTML"
         ],
-        "createbackup" => [],
+        "createbackup" => [
+            "maximumbackupspercron" => 10
+        ],
     ];
     private static $defaulttrigger = [
         "startdatedelay" => [

--- a/tests/manually_triggered_process_test.php
+++ b/tests/manually_triggered_process_test.php
@@ -19,6 +19,7 @@ defined('MOODLE_INTERNAL') || die();
 require_once(__DIR__ . '/generator/lib.php');
 require_once(__DIR__ . '/../lib.php');
 
+use tool_lifecycle\manager\settings_manager;
 use tool_lifecycle\manager\workflow_manager;
 use tool_lifecycle\manager\trigger_manager;
 use tool_lifecycle\manager\process_manager;
@@ -26,6 +27,7 @@ use tool_lifecycle\processor;
 
 /**
  * Manually triggers a process and tests if process courses proceeds the process as expected.
+ *
  * @package    tool_lifecycle
  * @category   test
  * @group      tool_lifecycle
@@ -49,7 +51,10 @@ class tool_lifecycle_manually_triggered_process_testcase extends \advanced_testc
         $triggersettings->displayname = self::MANUAL_TRIGGER1_DISPLAYNAME;
         $triggersettings->capability = self::MANUAL_TRIGGER1_CAPABILITY;
         $manualworkflow = $generator->create_manual_workflow($triggersettings);
-        $generator->create_step("instance1", "createbackup", $manualworkflow->id);
+        $step = $generator->create_step("instance1", "createbackup", $manualworkflow->id);
+        settings_manager::save_settings($step->id, SETTINGS_TYPE_STEP, "createbackup",
+                array("maximumbackupspercron" => 10)
+        );
 
         workflow_manager::handle_action(ACTION_WORKFLOW_ACTIVATE, $manualworkflow->id);
 

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 defined('MOODLE_INTERNAL') || die;
 
 $plugin->maturity = MATURITY_ALPHA;
-$plugin->version  = 2019051400;
+$plugin->version  = 2019052900;
 $plugin->component = 'tool_lifecycle';
 $plugin->requires = 2017111300; // Require Moodle 3.4 (or above).
 $plugin->release = 'v3.6-r1';


### PR DESCRIPTION
This adds a configuration to restrict the number of backups that can be done per cron.

This fixes #46 