### PR TITLE
Add start date options to start date delay trigger

### DIFF
--- a/trigger/startdatedelay/lang/en/lifecycletrigger_startdatedelay.php
+++ b/trigger/startdatedelay/lang/en/lifecycletrigger_startdatedelay.php
@@ -25,5 +25,11 @@
 
 $string['pluginname'] = 'Start date delay trigger';
 
-$string['delay'] = 'Delay from start of course until starting a process';
-$string['delay_help'] = 'The trigger will be invoked if the time passed since the course has started is longer than this delay.';
+$string['delay'] = 'Delay from startdate until starting a process';
+$string['delay_help'] = 'The trigger will be invoked if the time passed since the startdate is longer than this delay.';
+
+$string['startdate'] = 'Start date';
+$string['start_option'] = 'start date of course';
+$string['end_option'] = 'end date of course';
+$string['created_option'] = 'date of creation of course';
+$string['modified_option'] = 'date of last modification of course';

--- a/trigger/startdatedelay/lib.php
+++ b/trigger/startdatedelay/lib.php
@@ -73,29 +73,29 @@ class startdatedelay extends base_automatic {
 
     public function extend_add_instance_form_definition($mform) {
         $startoptions = array(
-            'startdate' => get_string('start_option', 'lifecycletrigger_startdatedelay'), 
-            'enddate'=>get_string('end_option', 'lifecycletrigger_startdatedelay'),
+            'startdate' => get_string('start_option', 'lifecycletrigger_startdatedelay'),
+            'enddate' => get_string('end_option', 'lifecycletrigger_startdatedelay'),
             'timecreated' => get_string('created_option', 'lifecycletrigger_startdatedelay'),
             'timemodified' => get_string('modified_option', 'lifecycletrigger_startdatedelay'),
         );
-        $mform->addElement('select', 'startdate',get_string('startdate', 'lifecycletrigger_startdatedelay'), $startoptions);
+        $mform->addElement('select', 'startdate', get_string('startdate', 'lifecycletrigger_startdatedelay'), $startoptions);
         $mform->addElement('duration', 'delay', get_string('delay', 'lifecycletrigger_startdatedelay'));
         $mform->addHelpButton('delay', 'delay', 'lifecycletrigger_startdatedelay');
     }
 
     public function extend_add_instance_form_definition_after_data($mform, $settings) {
         if (is_array($settings) && array_key_exists('delay', $settings)) {
-            $defaultDelay = $settings['delay'];
+            $defaultdelay = $settings['delay'];
         } else {
-            $defaultDelay = 16416000;
+            $defaultdelay = 16416000;
         }
-        $mform->setDefault('delay', $defaultDelay);
+        $mform->setDefault('delay', $defaultdelay);
 
         if (is_array($settings) && array_key_exists('startdate', $settings)) {
-            $defaultStartdate = $settings['startdate'];
+            $defaultstartdate = $settings['startdate'];
         } else {
-            $defaultStartdate = 'startdate';
+            $defaultstartdate = 'startdate';
         }
-        $mform->setDefault('startdate', $defaultStartdate);
+        $mform->setDefault('startdate', $defaultstartdate);
     }
 }

--- a/trigger/startdatedelay/lib.php
+++ b/trigger/startdatedelay/lib.php
@@ -52,7 +52,8 @@ class startdatedelay extends base_automatic {
 
     public function get_course_recordset_where($triggerid) {
         $delay = settings_manager::get_settings($triggerid, SETTINGS_TYPE_TRIGGER)['delay'];
-        $where = "{course}.startdate < :startdatedelay";
+        $startdate = settings_manager::get_settings($triggerid, SETTINGS_TYPE_TRIGGER)['startdate'];
+        $where = "{course}.".$startdate." < :startdatedelay";
         $params = array(
             "startdatedelay" => time() - $delay,
         );
@@ -65,21 +66,36 @@ class startdatedelay extends base_automatic {
 
     public function instance_settings() {
         return array(
-            new instance_setting('delay', PARAM_INT)
+            new instance_setting('delay', PARAM_INT),
+            new instance_setting('startdate', PARAM_TEXT)
         );
     }
 
     public function extend_add_instance_form_definition($mform) {
+        $startoptions = array(
+            'startdate' => get_string('start_option', 'lifecycletrigger_startdatedelay'), 
+            'enddate'=>get_string('end_option', 'lifecycletrigger_startdatedelay'),
+            'timecreated' => get_string('created_option', 'lifecycletrigger_startdatedelay'),
+            'timemodified' => get_string('modified_option', 'lifecycletrigger_startdatedelay'),
+        );
+        $mform->addElement('select', 'startdate',get_string('startdate', 'lifecycletrigger_startdatedelay'), $startoptions);
         $mform->addElement('duration', 'delay', get_string('delay', 'lifecycletrigger_startdatedelay'));
         $mform->addHelpButton('delay', 'delay', 'lifecycletrigger_startdatedelay');
     }
 
     public function extend_add_instance_form_definition_after_data($mform, $settings) {
         if (is_array($settings) && array_key_exists('delay', $settings)) {
-            $default = $settings['delay'];
+            $defaultDelay = $settings['delay'];
         } else {
-            $default = 16416000;
+            $defaultDelay = 16416000;
         }
-        $mform->setDefault('delay', $default);
+        $mform->setDefault('delay', $defaultDelay);
+
+        if (is_array($settings) && array_key_exists('startdate', $settings)) {
+            $defaultStartdate = $settings['startdate'];
+        } else {
+            $defaultStartdate = 'startdate';
+        }
+        $mform->setDefault('startdate', $defaultStartdate);
     }
 }

--- a/trigger/startdatedelay/tests/generator/lib.php
+++ b/trigger/startdatedelay/tests/generator/lib.php
@@ -36,7 +36,7 @@ class tool_lifecycle_trigger_startdatedelay_generator extends testing_module_gen
      * Creates a trigger startdatedelay for an artificial workflow without steps.
      * @return trigger_subplugin the created startdatedelay trigger.
      */
-    public static function create_trigger_with_workflow() {
+    public static function create_trigger_with_workflow($data) {
         // Create Workflow.
         $record = new stdClass();
         $record->id = null;
@@ -50,9 +50,10 @@ class tool_lifecycle_trigger_startdatedelay_generator extends testing_module_gen
         $record->workflowid = $workflow->id;
         $trigger = trigger_subplugin::from_record($record);
         trigger_manager::insert_or_update($trigger);
-        // Set delay setting.
+        // Set settings.
         $settings = new stdClass();
-        $settings->delay = 16416000;
+        $settings->delay = $data['delay'];
+        $settings->startdate = $data['startdate'];
         settings_manager::save_settings($trigger->id, SETTINGS_TYPE_TRIGGER, $trigger->subpluginname, $settings);
 
         return $trigger;

--- a/trigger/startdatedelay/tests/trigger_test.php
+++ b/trigger/startdatedelay/tests/trigger_test.php
@@ -44,7 +44,12 @@ class tool_lifecycle_trigger_startdatedelay_testcase extends \advanced_testcase 
         $this->setAdminUser();
 
         $this->processor = new processor();
-        $this->triggerinstance = \tool_lifecycle_trigger_startdatedelay_generator::create_trigger_with_workflow();
+
+        $data = array(
+            'startdate' => 'startdate',
+            'delay' => 16416000 // 190 Days
+        );
+        $this->triggerinstance = \tool_lifecycle_trigger_startdatedelay_generator::create_trigger_with_workflow($data);
     }
 
     /**


### PR DESCRIPTION
Hello,
 
I am a student assistant at the Beuth Hochschule für Technik Berlin. For our Moodle instance we need the possibility to delete Moodle courses that have not been modified for a long time. Therefore I changed the start date delay trigger to allow not only the start date of a course, but also the date of the last modification of a course.

Best regards