### PR TITLE
Add subplugins.json

### DIFF
--- a/db/subplugins.json
+++ b/db/subplugins.json
@@ -1,0 +1,6 @@
+{
+  "plugintypes" : {
+    "lifecycletrigger" : "admin\/tool\/lifecycle\/trigger",
+    "lifecyclestep" : "admin\/tool\/lifecycle\/step"
+  }
+}

--- a/db/subplugins.php
+++ b/db/subplugins.php
@@ -23,7 +23,4 @@
  */
 defined('MOODLE_INTERNAL') || die();
 
-$subplugins = array(
-    'lifecycletrigger' => 'admin/tool/lifecycle/trigger',
-    'lifecyclestep' => 'admin/tool/lifecycle/step',
-);
+$subplugins = json_decode(file_get_contents(__DIR__ . '/subplugins.json'), true)["plugintypes"];


### PR DESCRIPTION
Escaping the slashes in subplugins.json is not required, but allowed, and since all json files in the moodle core do it that way, I did the same.