### PR TITLE
Add config for the backup dir path

### DIFF
--- a/classes/local/manager/backup_manager.php
+++ b/classes/local/manager/backup_manager.php
@@ -58,7 +58,7 @@ class backup_manager {
             $archivefile = date("Y-m-d") . "-ID-{$recordid}-COURSE-{$courseid}.mbz";
 
             // Path of backup folder.
-            $path = $CFG->dataroot . '/lifecycle_backups';
+            $path = get_config('tool_lifecycle', 'backup_path');
             // If the path doesn't exist, make it so!
             if (!is_dir($path)) {
                 umask(0000);
@@ -119,7 +119,7 @@ class backup_manager {
         $targetfilename = \restore_controller::get_tempdir_name($backuprecord->courseid, get_admin()->id);
         $target = $backuptmpdir . '/' . $targetfilename;
         // Create the location of the actual backup file.
-        $source = $CFG->dataroot . '/lifecycle_backups/' . $backuprecord->backupfile;
+        $source = get_config('tool_lifecycle', 'backup_path') . DIRECTORY_SEPARATOR . $backuprecord->backupfile;
         // Check if the backup file exists.
         if (!file_exists($source)) {
             throw new \moodle_exception('errorbackupfiledoesnotexist', 'tool_lifecycle', $source);

--- a/classes/local/manager/backup_manager.php
+++ b/classes/local/manager/backup_manager.php
@@ -75,13 +75,13 @@ class backup_manager {
             /* @var $file \stored_file instance of the backup file*/
             $file = $results['backup_destination'];
             if (!empty($file)) {
-                $file->copy_content_to($path . '/' . $archivefile);
+                $file->copy_content_to($path . DIRECTORY_SEPARATOR . $archivefile);
             }
             $bc->destroy();
             unset($bc);
 
             // First check if the file was created.
-            if (!file_exists($path . '/' . $archivefile)) {
+            if (!file_exists($path . DIRECTORY_SEPARATOR . $archivefile)) {
                 return false;
             }
 
@@ -110,14 +110,14 @@ class backup_manager {
         $backuprecord = $DB->get_record('tool_lifecycle_backups', array('id' => $backupid));
 
         // Check if backup tmp dir exists.
-        $backuptmpdir = $CFG->tempdir . '/backup';
+        $backuptmpdir = $CFG->tempdir . DIRECTORY_SEPARATOR . 'backup';
         if (!check_dir_exists($backuptmpdir, true, true)) {
             throw new \restore_controller_exception('cannot_create_backup_temp_dir');
         }
 
         // Create the file location in the backup temp.
         $targetfilename = \restore_controller::get_tempdir_name($backuprecord->courseid, get_admin()->id);
-        $target = $backuptmpdir . '/' . $targetfilename;
+        $target = $backuptmpdir . DIRECTORY_SEPARATOR . $targetfilename;
         // Create the location of the actual backup file.
         $source = get_config('tool_lifecycle', 'backup_path') . DIRECTORY_SEPARATOR . $backuprecord->backupfile;
         // Check if the backup file exists.

--- a/downloadbackup.php
+++ b/downloadbackup.php
@@ -29,7 +29,7 @@ require_capability('moodle/site:config', context_system::instance());
 $backupid = required_param('backupid', PARAM_INT);
 
 $backuprecord = $DB->get_record('tool_lifecycle_backups', array('id' => $backupid), 'backupfile', MUST_EXIST);
-$source = $CFG->dataroot . '/lifecycle_backups/' . $backuprecord->backupfile;
+$source = get_config('tool_lifecycle', 'backup_path') . DIRECTORY_SEPARATOR . $backuprecord->backupfile;
 
 if (!file_exists($source)) {
     throw new \moodle_exception('errorbackupfiledoesnotexist', 'tool_lifecycle', $source);

--- a/lang/en/tool_lifecycle.php
+++ b/lang/en/tool_lifecycle.php
@@ -34,6 +34,9 @@ $string['config_delay_duration'] = 'Default duration of a course delay';
 $string['config_delay_duration_desc'] = 'This setting defines the default delay duration of a workflow
 in case one of its processes is rolled back or finishes.
 The delay duration determines how long a course will be excepted from being processed again in either of the cases.';
+$string['config_backup_path'] = 'Path of the lifecycle backup folder';
+$string['config_backup_path_desc'] = 'This settings defines the storage location of the backups created by the backup step.
+The path has to be specified as an absolute path on your server.';
 $string['active_processes_list_header'] = 'Active processes';
 $string['adminsettings_heading'] = 'Workflow settings';
 $string['active_manual_workflows_heading'] = 'Active manual workflows';

--- a/settings.php
+++ b/settings.php
@@ -38,6 +38,11 @@ if ($hassiteconfig) {
         get_string('config_delay_duration_desc', 'tool_lifecycle'),
         183 * 24 * 60 * 60)); // Dafault value is 180 days.
 
+    $settings->add(new admin_setting_configtext('tool_lifecycle/backup_path',
+        get_string('config_backup_path', 'tool_lifecycle'),
+        get_string('config_backup_path_desc', 'tool_lifecycle'),
+        $CFG->dataroot . DIRECTORY_SEPARATOR . 'lifecycle_backups'));
+
     $ADMIN->add('lifecycle_category', new tool_lifecycle\admin_page_active_processes());
     $ADMIN->add('lifecycle_category', new tool_lifecycle\admin_page_course_backups());
     $ADMIN->add('lifecycle_category', new tool_lifecycle\admin_page_sublugins());

--- a/settings.php
+++ b/settings.php
@@ -38,7 +38,7 @@ if ($hassiteconfig) {
         get_string('config_delay_duration_desc', 'tool_lifecycle'),
         183 * 24 * 60 * 60)); // Dafault value is 180 days.
 
-    $settings->add(new admin_setting_configtext('tool_lifecycle/backup_path',
+    $settings->add(new admin_setting_configdirectory('tool_lifecycle/backup_path',
         get_string('config_backup_path', 'tool_lifecycle'),
         get_string('config_backup_path_desc', 'tool_lifecycle'),
         $CFG->dataroot . DIRECTORY_SEPARATOR . 'lifecycle_backups'));

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die;
 
 $plugin->maturity = MATURITY_BETA;
-$plugin->version  = 2019120200;
+$plugin->version  = 2019120201;
 $plugin->component = 'tool_lifecycle';
 $plugin->requires = 2017111300; // Require Moodle 3.4 (or above).
 $plugin->release = 'v3.8-r1';


### PR DESCRIPTION
This PR allows to set a path for the backup dir. This way it is easier for system administrators to place the backups folder in a separate storage space.