### PR TITLE
Delete course step: delete waiting courses

### DIFF
--- a/step/deletecourse/lib.php
+++ b/step/deletecourse/lib.php
@@ -67,6 +67,21 @@ class deletecourse extends libbase {
     }
 
     /**
+     * Processes the course in status waiting and returns a repsonse.
+     * The response tells either
+     *  - that the subplugin is finished processing.
+     *  - that the subplugin is not yet finished processing.
+     *  - that a rollback for this course is necessary.
+     * @param int $processid of the respective process.
+     * @param int $instanceid of the step instance.
+     * @param mixed $course to be processed.
+     * @return step_response
+     */
+    public function process_waiting_course($processid, $instanceid, $course) {
+        return $this->process_course($processid, $instanceid, $course);
+    }
+
+    /**
      * The return value should be equivalent with the name of the subplugin folder.
      * @return string technical name of the subplugin
      */


### PR DESCRIPTION
The delete course step should override the `process_waiting_course` function in order to process waiting courses correctly. Courses will be waiting in this step when `$numberofdeletions` exceeds the maximum.

You may also consider to change the implementation of `\tool_lifecycle\step\libbase::process_waiting_course()`. Maybe throw an exception. If your `process_course()` may return a waiting response, you probably want to override the `process_waiting_course` function in your class.