### PR TITLE
Throw exception in process_waiting_course if called and not overridden

### DIFF
--- a/step/lib.php
+++ b/step/lib.php
@@ -64,7 +64,7 @@ abstract class libbase {
      * @return step_response
      */
     public function process_waiting_course($processid, $instanceid, $course) {
-        return step_response::proceed();
+        throw new \coding_exception("Processing of waiting courses is not supported for this workflow step.");
     }
 
     /**


### PR DESCRIPTION
This changes the default of just proceeding a course. However, I can not
think of a scenario were this would make sense.

Folllow up on #103