### PR TITLE
Use backup settings from automated backups

### DIFF
--- a/classes/local/manager/backup_manager.php
+++ b/classes/local/manager/backup_manager.php
@@ -69,7 +69,7 @@ class backup_manager {
             }
             // Perform Backup.
             $bc = new \backup_controller(\backup::TYPE_1COURSE, $courseid, \backup::FORMAT_MOODLE,
-                \backup::INTERACTIVE_NO, \backup::MODE_GENERAL, get_admin()->id);
+                \backup::INTERACTIVE_NO, \backup::MODE_AUTOMATED, get_admin()->id);
             $bc->execute_plan();  // Execute backup.
             $results = $bc->get_results(); // Get the file information needed.
             /* @var $file \stored_file instance of the backup file*/


### PR DESCRIPTION
Currently, the backup settings from the general backups are used for creation of backups within tool_lifecycle. We changed this for two reasons.
The first one is the obvious: tool_lifecycle creates the backups automatically.
The second reason is that the backups of tool_lifecycle should have the same contents as the automated backups by moodle. This way, we can delete the automated moodle backups, when we finally delete the course.