### PR TITLE
Abort and delete processes whose courses got deleted

### DIFF
--- a/classes/local/manager/process_manager.php
+++ b/classes/local/manager/process_manager.php
@@ -230,10 +230,19 @@ class process_manager {
     public static function course_deletion_observed($event) {
         $process = self::get_process_by_course_id($event->get_data()['courseid']);
         if ($process) {
-            $step = step_manager::get_step_instance_by_workflow_index($process->workflowid, $process->stepindex);
-            $steplib = lib_manager::get_step_lib($step->subpluginname);
-            $steplib->abort_course($process);
-            self::remove_process($process);
+            self::abort_process($process);
         }
+    }
+
+    /**
+     * Aborts a running process.
+     * @param process $process The process to abort.
+     * @throws \dml_exception
+     */
+    public static function abort_process($process) {
+        $step = step_manager::get_step_instance_by_workflow_index($process->workflowid, $process->stepindex);
+        $steplib = lib_manager::get_step_lib($step->subpluginname);
+        $steplib->abort_course($process);
+        self::remove_process($process);
     }
 }

--- a/db/events.php
+++ b/db/events.php
@@ -1,0 +1,32 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Event observer.
+ *
+ * @package   tool_lifecycle
+ * @copyright 2020 Justus Dieckmann WWU
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$observers = array(
+        array(
+                'eventname' => 'core\event\course_deleted',
+                'callback' => 'tool_lifecycle\local\manager\process_manager::course_deletion_observed',
+        )
+);

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -433,5 +433,18 @@ function xmldb_tool_lifecycle_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2019082300, 'tool', 'lifecycle');
     }
 
+    if ($oldversion < 2020091800) {
+        $sql = "SELECT p.* FROM {tool_lifecycle_process} p " .
+                "LEFT JOIN {course} c ON p.courseid = c.id " .
+                "WHERE c.id IS NULL";
+        $processes = $DB->get_records_sql($sql);
+        foreach ($processes as $procrecord) {
+            $process = \tool_lifecycle\local\entity\process::from_record($procrecord);
+            \tool_lifecycle\local\manager\process_manager::abort_process($process);
+        }
+
+        upgrade_plugin_savepoint(true, 2020091800, 'tool', 'lifecycle');
+    }
+
     return true;
 }

--- a/step/lib.php
+++ b/step/lib.php
@@ -24,6 +24,7 @@
  */
 namespace tool_lifecycle\step;
 
+use tool_lifecycle\local\entity\process;
 use tool_lifecycle\local\manager\step_manager;
 use tool_lifecycle\local\response\step_response;
 
@@ -121,6 +122,14 @@ abstract class libbase {
      * @param array $settings array containing the settings from the db.
      */
     public function extend_add_instance_form_definition_after_data($mform, $settings) {
+    }
+
+    /**
+     * This method can be overridden. It is called when a course and the
+     * corresponding process get deleted.
+     * @param process $process the process that was aborted.
+     */
+    public function abort_course($process) {
     }
 
 }

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die;
 
 $plugin->maturity = MATURITY_BETA;
-$plugin->version  = 2020060500;
+$plugin->version  = 2020091800;
 $plugin->component = 'tool_lifecycle';
 $plugin->requires = 2017111300; // Require Moodle 3.4 (or above).
 $plugin->release = 'v3.9-r1';


### PR DESCRIPTION
Deletes a process when the corresponding course is deleted and calls the `abort_course()` method of the steplib of the current step.
Adresses learnweb/moodle-lifecyclestep_adminapprove#22
