### PR TITLE
Category trigger : select categories with paths

### DIFF
--- a/trigger/categories/lib.php
+++ b/trigger/categories/lib.php
@@ -117,9 +117,7 @@ class categories extends base_automatic {
      * @throws \dml_exception
      */
     public function extend_add_instance_form_definition($mform) {
-        
         $displaylist = core_course_category::make_categories_list();
-        
         $options = array(
             'multiple' => true,
             'noselectionstring' => get_string('categories_noselection', 'lifecycletrigger_categories'),

--- a/trigger/categories/lib.php
+++ b/trigger/categories/lib.php
@@ -117,18 +117,23 @@ class categories extends base_automatic {
      */
     public function extend_add_instance_form_definition($mform) {
         global $DB;
+        $displaylist = core_course_category::make_categories_list();
+        
+        /*
         $categories = $DB->get_records('course_categories');
         $categorynames = array();
         foreach ($categories as $category) {
             $categorynames[$category->id] = $category->name;
         }
+        */
+
         $options = array(
             'multiple' => true,
             'noselectionstring' => get_string('categories_noselection', 'lifecycletrigger_categories'),
         );
         $mform->addElement('autocomplete', 'categories',
             get_string('categories', 'lifecycletrigger_categories'),
-            $categorynames, $options);
+            $displaylist, $options);
         $mform->setType('categories', PARAM_SEQUENCE);
 
         $mform->addElement('advcheckbox', 'exclude', get_string('exclude', 'lifecycletrigger_categories'));

--- a/trigger/categories/lib.php
+++ b/trigger/categories/lib.php
@@ -27,6 +27,7 @@ use coursecat;
 use tool_lifecycle\local\manager\settings_manager;
 use tool_lifecycle\local\response\trigger_response;
 use tool_lifecycle\settings_type;
+use core_course_category;
 
 defined('MOODLE_INTERNAL') || die();
 require_once(__DIR__ . '/../lib.php');

--- a/trigger/categories/lib.php
+++ b/trigger/categories/lib.php
@@ -117,7 +117,7 @@ class categories extends base_automatic {
      * @throws \dml_exception
      */
     public function extend_add_instance_form_definition($mform) {
-        global $DB;
+        
         $displaylist = core_course_category::make_categories_list();
         
         $options = array(

--- a/trigger/categories/lib.php
+++ b/trigger/categories/lib.php
@@ -120,14 +120,6 @@ class categories extends base_automatic {
         global $DB;
         $displaylist = core_course_category::make_categories_list();
         
-        /*
-        $categories = $DB->get_records('course_categories');
-        $categorynames = array();
-        foreach ($categories as $category) {
-            $categorynames[$category->id] = $category->name;
-        }
-        */
-
         $options = array(
             'multiple' => true,
             'noselectionstring' => get_string('categories_noselection', 'lifecycletrigger_categories'),


### PR DESCRIPTION
This adds category paths on settings page. 
It's needed to when there's multiple categories with same name.

This was quite straight forward to add by using following moodle core class 
core_course_category::make_categories_list()




