### PR TITLE
Add event for proper hooks for block_mbstreatcourses

### DIFF
--- a/classes/event/process_processed.php
+++ b/classes/event/process_processed.php
@@ -1,0 +1,146 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * The process_processed event.
+ *
+ * @package    tool_lifecycle
+ * @copyright  2022 ISB Bayern
+ * @author     Philipp Memmel
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+namespace tool_lifecycle\event;
+
+use coding_exception;
+use core\event\base;
+use dml_exception;
+use moodle_url;
+
+/**
+ * The process_processed event class.
+ *
+ * In contrast to the events {@link process_proceeded} and {@link process_rollback} this event is being fired after the process
+ * has been fully handled. So there is a chance the process has already been removed when this event is being received.
+ *
+ * @property-read array $other {
+ *      Extra information about event.
+ *
+ *      - int processid: the id of the process.
+ *      - int workflowid: the id of the workflow.
+ *      - int courseid: the id of the course.
+ * };
+ *
+ * @package    tool_lifecycle
+ * @copyright  2022 ISB Bayern
+ * @author     Philipp Memmel
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class process_processed extends base {
+
+    /**
+     * Creates an event with a process id.
+     *
+     * @param int $processid the id of the process
+     * @param int $workflowid the id of the workflow of the process with $processid
+     * @param int $courseid the id of the course the process is handling
+     * @return base
+     * @throws coding_exception
+     * @throws dml_exception
+     */
+    public static function event_from_process($processid, $workflowid, $courseid): base {
+        $data = array(
+                'context' => \context_system::instance(),
+                'other' => array(
+                    'processid' => $processid,
+                    'workflowid' => $workflowid,
+                    'courseid' => $courseid
+                )
+        );
+        return self::create($data);
+    }
+
+    /**
+     * Init method.
+     *
+     * @return void
+     */
+    protected function init() {
+        $this->data['crud'] = 'u';
+        $this->data['edulevel'] = self::LEVEL_OTHER;
+    }
+
+    /**
+     * Returns description of what happened.
+     *
+     * @return string
+     */
+    public function get_description() {
+        $processid = $this->other['processid'];
+        $workflowid = $this->other['workflowid'];
+        $courseid = $this->other['courseid'];
+
+        return "The process with id '$processid' and the corresponding workflow with id '$workflowid' "
+            . "for the course with the id '$courseid' has been changed.";
+    }
+
+    /**
+     * Return localised event name.
+     *
+     * @return string
+     * @throws coding_exception
+     */
+    public static function get_name() {
+        return get_string('process_processed_event', 'tool_lifecycle');
+    }
+
+    /**
+     * Returns relevant URL.
+     *
+     * @return moodle_url
+     */
+    public function get_url() {
+        return new moodle_url('/admin/tool/lifecycle/view.php');
+    }
+
+    /**
+     * Custom validation.
+     *
+     * @throws coding_exception
+     */
+    protected function validate_data() {
+        parent::validate_data();
+
+        if (!isset($this->other['processid'])) {
+            throw new coding_exception('The \'processid\' value must be set');
+        }
+
+        if (!isset($this->other['workflowid'])) {
+            throw new coding_exception('The \'workflowid\' value must be set');
+        }
+
+        if (!isset($this->other['courseid'])) {
+            throw new coding_exception('The \'courseid\' value must be set');
+        }
+    }
+
+    /**
+     * Implementation of get_other_mapping.
+     */
+    public static function get_other_mapping() {
+        // No backup and restore.
+        return false;
+    }
+}

--- a/lang/de/tool_lifecycle.php
+++ b/lang/de/tool_lifecycle.php
@@ -174,6 +174,7 @@ $string['restore_trigger_does_not_exist'] = 'Der Trigger {$a} ist nicht installi
 
 $string['process_triggered_event'] = 'Ein Prozess wurde ausgelöst';
 $string['process_proceeded_event'] = 'Ein Prozess wurde fortgeführt';
+$string['process_processed_event'] = 'Ein Prozess wurde behandelt';
 $string['process_rollback_event'] = 'Ein Prozess wurde zurückgesetzt';
 
 $string['courseid'] = 'Kurs-ID';

--- a/lang/en/tool_lifecycle.php
+++ b/lang/en/tool_lifecycle.php
@@ -181,6 +181,7 @@ $string['restore_trigger_does_not_exist'] = 'The trigger {$a} is not installed, 
 // Events.
 $string['process_triggered_event'] = 'A process has been triggered';
 $string['process_proceeded_event'] = 'A process has been proceeded';
+$string['process_processed_event'] = 'A process has been treated';
 $string['process_rollback_event'] = 'A process has been rolled back';
 
 // Privacy API.


### PR DESCRIPTION
In some cases you want to react to events fired by tool_lifecycle **after** the corresponding database actions have been performed, so you can read from the database again to have a consistent database state.

This PR adds such an event.