### PR TITLE
MBS-6313: Adding Lang String for cache definition

### DIFF
--- a/lang/en/tool_lifecycle.php
+++ b/lang/en/tool_lifecycle.php
@@ -25,6 +25,7 @@
 
 $string['pluginname'] = 'Life Cycle';
 $string['plugintitle'] = 'Course Life Cycle';
+$string['cachedef_mformdata'] = 'Caches the mform data.';
 
 $string['lifecycle:managecourses'] = 'May manage courses in tool_lifecycle';
 $string['managecourses_link'] = 'Manage courses';


### PR DESCRIPTION
Adds a language string for the cache definition to fix an error in the execution of the unit tests.