### PR TITLE
MBS-7081: Fix unit test error in process_error_test.php for PHP 8.0

### DIFF
--- a/tests/process_error_test.php
+++ b/tests/process_error_test.php
@@ -109,7 +109,11 @@ class process_error_test extends \advanced_testcase {
         $record = reset($records);
 
         $this->assertEquals($this->course->id, $record->courseid);
-        $this->assertStringContainsString("Trying to get property 'id' of non-object", $record->errormessage);
+        if (version_compare(PHP_VERSION, '8.0', '<')) {
+            $this->assertStringContainsString("Trying to get property 'id' of non-object", $record->errormessage);
+        } else {
+            $this->assertStringContainsString("Attempt to read property \"id\" on bool", $record->errormessage);
+        }
         $this->assertEquals($process->id, $record->id);
     }
 


### PR DESCRIPTION
Using `tool_lifecycle` with PHP 8.0 results in a unit test error because an error message is being asserted which has changed in PHP 8.0.

I made the patch backwards compatible for PHP 7.4