### PR TITLE
Log step currently processed

### DIFF
--- a/classes/processor.php
+++ b/classes/processor.php
@@ -116,6 +116,7 @@ class processor {
 
                 $step = step_manager::get_step_instance_by_workflow_index($process->workflowid, $process->stepindex);
                 $lib = lib_manager::get_step_lib($step->subpluginname);
+                mtrace("Processing '$step->subpluginname' step on course $course->id...");
                 try {
                     if ($process->waiting) {
                         $result = $lib->process_waiting_course($process->id, $step->id, $course);


### PR DESCRIPTION
Extend the workflow log with the sub-plugin name of the step currently being processed and the course ID.

Beyond that, there are probably additional ways to improve logging.