### PR TITLE
Inform only active users by email step

### DIFF
--- a/step/email/lib.php
+++ b/step/email/lib.php
@@ -60,7 +60,8 @@ class email extends libbase {
     public function process_course($processid, $instanceid, $course) {
         global $DB;
         $coursecontext = \context_course::instance($course->id);
-        $userstobeinformed = get_users_by_capability($coursecontext, 'lifecyclestep/email:preventdeletion');
+        $userstobeinformed = get_enrolled_users($coursecontext, 'lifecyclestep/email:preventdeletion', 0,
+            'u.id', null, null, null, true);
         foreach ($userstobeinformed as $user) {
             $record = new \stdClass();
             $record->touser = $user->id;


### PR DESCRIPTION
We noticed that all enrolled users with the 'lifecyclestep/email:preventdeletion' capability are 
informed by the E-Mail-Step.
We think only the users with `ENROL_USER_ACTIVE` should be informed.

It could also be a separate setting, but for now i changed the way `$userstobeinformed` is retrieved.

Greetings 
Felix