### PR TITLE
fix error when otherindex does not exist

### DIFF
--- a/classes/local/manager/workflow_manager.php
+++ b/classes/local/manager/workflow_manager.php
@@ -366,12 +366,14 @@ class workflow_manager {
             [
                 'sortindex' => $otherindex, ]
         );
-        $otherworkflow = workflow::from_record($otherrecord);
+        if (false !== $otherrecord) {
+            $otherworkflow = workflow::from_record($otherrecord);
+            $otherworkflow->sortindex = $index;
+            self::insert_or_update($otherworkflow);
+        }
 
         $workflow->sortindex = $otherindex;
-        $otherworkflow->sortindex = $index;
         self::insert_or_update($workflow);
-        self::insert_or_update($otherworkflow);
 
         $transaction->allow_commit();
     }


### PR DESCRIPTION
Scenario:
When a workflow is deactivated the assigned sortindex is "missing" in the workflow table.
If you want to move another, still active workflow to this position, a fatal error occurs:

![grafik](https://github.com/learnweb/moodle-tool_lifecycle/assets/66598405/202a3920-0a81-4106-b55b-9120c29136dd)

This patch prevents this fatal error by omitting changes to a workflow which does not exist.