### PR TITLE
Improve help text for integration of icons (manual trigger)

### DIFF
--- a/trigger/manual/lang/de/lifecycletrigger_manual.php
+++ b/trigger/manual/lang/de/lifecycletrigger_manual.php
@@ -27,6 +27,6 @@ $string['privacy:metadata'] = 'Dieses Subplugin speichert keine persönlichen Da
 $string['setting_capability'] = 'Berechtigung';
 $string['setting_capability_help'] = 'Die Moodle-Berechtigung, die ein Nutzer benötigt, um einen Workflow mit diesem Trigger zu sehen und auszulösen, z.B. "enrol/manual:enrol". Bitte schauen Sie sich die Moodle Access API für Details an.';
 $string['setting_icon'] = 'Icon';
-$string['setting_icon_help'] = 'Das Moodle-Icon das dem Nutzer für diesen Trigger angezeigt wird, z.B. "core/tick". Die ganze Liste möglicher Icons kann in der Moodle-Dokumentation gefunden werden.';
+$string['setting_icon_help'] = 'Das Moodle-Icon das dem Nutzer für diesen Trigger angezeigt wird, z.B. "e/tick". Die ganze Liste möglicher Icons kann in der Moodle-Dokumentation gefunden werden.';
 $string['setting_displayname'] = 'Aktionsname';
 $string['setting_displayname_help'] = 'Der Name für die Triggeraktion, der dem Nutzer angezeigt wird.';

--- a/trigger/manual/lang/en/lifecycletrigger_manual.php
+++ b/trigger/manual/lang/en/lifecycletrigger_manual.php
@@ -27,6 +27,6 @@ $string['privacy:metadata'] = 'This subplugin does not store any personal data.'
 $string['setting_capability'] = 'Capability';
 $string['setting_capability_help'] = 'The Moodle capability needed to see and invoke a workflow using this trigger, e.g. "enrol/manual:enrol". Please see Moodle access API documentation for details.';
 $string['setting_icon'] = 'Icon';
-$string['setting_icon_help'] = 'The Moodle icon to be showed to the user for this trigger, e.g. "core/tick". A full list of possible icons can be found at Moodle documentation.';
+$string['setting_icon_help'] = 'The Moodle icon to be showed to the user for this trigger, e.g. "e/tick". A full list of possible icons can be found at Moodle documentation.';
 $string['setting_displayname'] = 'Action name';
 $string['setting_displayname_help'] = 'A name for the trigger action displayed to the user.';


### PR DESCRIPTION
Hi!

This should solve #176 . The help text was a little bit misleading because it produced an error (icon not showing up). I'm not sure if moodle had recently changed something regarding the integration of the icons. 

Kind regards!