### PR TITLE
Add checkbox to admin setting for trigger: specificdate and fix 'delete & backup (other) course afterwards' error, which is created by moodle core issue MDL-65228

### DIFF
--- a/step/deletecourse/lib.php
+++ b/step/deletecourse/lib.php
@@ -57,11 +57,20 @@ class deletecourse extends libbase {
      * @throws \dml_exception
      */
     public function process_course($processid, $instanceid, $course) {
+        global $CFG;
+
         if (self::$numberofdeletions >= settings_manager::get_settings(
             $instanceid, settings_type::STEP)['maximumdeletionspercron']) {
             return step_response::waiting(); // Wait with further deletions til the next cron run.
         }
         delete_course($course->id, true);
+
+        // Fix 'delete & backup (other) course aftwerwards' error, which is created by moodle core issue MDL-65228 (https://tracker.moodle.org/browse/MDL-65228)
+        if(is_object($CFG) && property_exists($CFG, "forced_plugin_settings") && is_array($CFG->forced_plugin_settings)
+                && array_key_exists("backup", $CFG->forced_plugin_settings) && !is_array($CFG->forced_plugin_settings["backup"])) {
+            $CFG->forced_plugin_settings["backup"] = [];
+        }
+
         self::$numberofdeletions++;
         return step_response::proceed();
     }

--- a/trigger/specificdate/lang/de/lifecycletrigger_specificdate.php
+++ b/trigger/specificdate/lang/de/lifecycletrigger_specificdate.php
@@ -27,5 +27,5 @@ $string['dates_help'] = 'Ein Datum pro Zeile in dem Format Tag.Monat<br><br>Zum 
 $string['dates_not_parseable'] = 'Daten müssen in dem Format Tag.Monat sein!';
 $string['pluginname'] = 'Bestimmtes Datum - Trigger';
 $string['privacy:metadata'] = 'Dieses Subplugin speichert keine persönlichen Daten.';
-
+$string['timelastrunactive'] = 'Nur einmal pro Tag';
 $string['timelastrun'] = 'Datum, an dem der Trigger zuletzt ausgeführt wurde.';

--- a/trigger/specificdate/lang/en/lifecycletrigger_specificdate.php
+++ b/trigger/specificdate/lang/en/lifecycletrigger_specificdate.php
@@ -27,5 +27,5 @@ $string['dates_help'] = 'Write one date per line with the format Day.Month<br><b
 $string['dates_not_parseable'] = 'Dates must be of the format Day.Month';
 $string['pluginname'] = 'Specific date trigger';
 $string['privacy:metadata'] = 'This subplugin does not store any personal data.';
-
+$string['timelastrunactive'] = 'Only once a day';
 $string['timelastrun'] = 'Date when the trigger last run.';

--- a/trigger/specificdate/lib.php
+++ b/trigger/specificdate/lib.php
@@ -66,6 +66,8 @@ class specificdate extends base_automatic {
         $settings = settings_manager::get_settings($triggerid, settings_type::TRIGGER);
         $datesraw = $settings['dates'];
         $dates = $this->parse_dates($datesraw);
+        // Get timelastrunactive
+        $timelastrunactive = $settings['timelastrunactive'];
         $lastrun = getdate($settings['timelastrun']);
         $current = time();
         $today = getdate($current);
@@ -74,7 +76,7 @@ class specificdate extends base_automatic {
             // We want to trigger only if the $date is today.
             if ($date['mon'] == $today['mon'] && $date['day'] == $today['mday']) {
                 // Now only make sure if $lastrun was today -> don't trigger.
-                if ($lastrun['yday'] == $today['yday'] && $lastrun['year'] == $today['year']) {
+                if ($timelastrunactive && $lastrun['yday'] == $today['yday'] && $lastrun['year'] == $today['year']) {
                     continue;
                 } else {
                     $settings['timelastrun'] = $current;
@@ -124,6 +126,8 @@ class specificdate extends base_automatic {
     public function instance_settings() {
         return [
             new instance_setting('dates', PARAM_TEXT),
+            // Add activate timelastrun
+            new instance_setting('timelastrunactive', PARAM_INT),
             new instance_setting('timelastrun', PARAM_INT),
         ];
     }
@@ -138,6 +142,10 @@ class specificdate extends base_automatic {
         $mform->addElement('textarea', 'dates', get_string('dates', 'lifecycletrigger_specificdate'));
         $mform->setType('dates', PARAM_TEXT);
         $mform->addHelpButton('dates', 'dates', 'lifecycletrigger_specificdate');
+        // Add activate timelastrun
+        $mform->addElement('advcheckbox', 'timelastrunactive', get_string('timelastrunactive', 'lifecycletrigger_specificjku'));
+        $mform->setDefault('timelastrunactive', 1);
+        //$mform->disabledIf('timelastrun', 'timelastrunactive');
         $mform->addElement('hidden', 'timelastrun');
         $mform->setDefault('timelastrun', 0);
         $mform->setType('timelastrun', PARAM_INT);


### PR DESCRIPTION
Add checkbox to admin setting for trigger: specificdate to de & activate trigger only once a day.

![Add checkbox Only once a day](https://github.com/user-attachments/assets/adfad267-4625-48f1-94b6-f4da684fddc2)
