### PR TITLE
Allow steps to run when course no longer exits (#222)

### DIFF
--- a/classes/processor.php
+++ b/classes/processor.php
@@ -102,8 +102,9 @@ class processor {
                 try {
                     $course = get_course($process->courseid);
                 } catch (\dml_missing_record_exception $e) {
-                    // Course no longer exists!
-                    break;
+                    mtrace("The course with id {$process->courseid} no longer exists. New stdClass with id property is created.");
+                    $course = new \stdClass();
+                    $course->id = $process->courseid;
                 }
 
                 if ($process->stepindex == 0) {


### PR DESCRIPTION
This creates a stdClass object populating only the id, presenting as a course object. This allows steps to run after a course has been deleted. 

Closes #222. 