### PR TITLE
Fix error when course is already deleted #251

### DIFF
--- a/classes/local/entity/process.php
+++ b/classes/local/entity/process.php
@@ -104,7 +104,14 @@ class process {
             $stepindex = 0;
         }
 
-        $context = \context_course::instance($record->courseid);
+        // IT.Serv start: add try/catch to prevent error when course is already deleted.
+        try {
+            $context = \context_course::instance($record->courseid);
+        } catch (\Exception $e) {
+            $context = false;
+        }
+        // IT.Serv end: add try/catch to prevent error when course is already deleted.
+
         $instance = new self($record->id,
                 $record->workflowid,
                 $record->courseid,


### PR DESCRIPTION
…#251

### 🔀 Purpose of this PR:

- [x] Fixes a bug

---

### 📝 Description:

See #251 

---

### 📋 Checklist

Please confirm the following (check all that apply):

- [x] Code passes the code checker without errors and warnings.
- [x] Code passes the moodle-ci/cd pipeline on all supported Moodle versions or the ones the plugin supports.
- [x] Code does not have `var_dump()` or `var_export` or any other debugging statements (or commented out code) that
  should not appear on the productive branch.

---

### 🔍 Related Issues

- Related to #251 251

---
