### PR TITLE
Fix: Issue #255 Remove problematic use of optional_param()

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -33,9 +33,8 @@ if ($hassiteconfig) {
     $settings = new admin_settingpage('lifecycle', get_string('pluginname', 'tool_lifecycle'));
 
     $tabrow = tabs::get_tabrow();
-    $id = optional_param('id', 'settings', PARAM_TEXT);
     $tabs = [$tabrow];
-    $tabsoutput = print_tabs($tabs, $id, null, null, true);
+    $tabsoutput = print_tabs($tabs, 'settings', null, null, true);
 
     // Main config page.
     $settings->add(new admin_setting_heading('lifecycle_settings_heading',


### PR DESCRIPTION
> **Note:** Please fill out all relevant sections and remove irrelevant ones.
### 🔀 Purpose of this PR:

- [x] Fixes a bug
- [ ] Updates for a new Moodle version
- [ ] Adds a new feature of functionality
- [ ] Improves or enhances existing features
- [ ] Refactoring: restructures code for better performance or maintainability
- [ ] Testing: add missing or improve existing tests
- [ ] Miscellaneous: code cleaning (without functional changes), documentation, configuration, ...

---

### 📝 Description:

Please describe the purpose of this PR in a few sentences.

- What feature or bug does it address?

1. This PR fixes an issue in the settings.php page of the tool_lifecycle plugin where the url id parameter handling via use of the method optional_param() contains an array. When an array is passed in a fatal error can be thrown in other plugins installed on a given Moodle site given certain (somewhat common) conditions are met.

- Why is this change or addition necessary?

1. Without this fix, certain admin actions or invalid query strings can trigger PHP warnings or exceptions due to unexpected parameter types.
2. The following use of optional_param() https://github.com/learnweb/moodle-tool_lifecycle/blob/MOODLE_405_STABLE/settings.php#L36 in this plugin doesn't accept array value types in the first parameter but an array can be passed in when a Moodle form is submitted and an admin page is set up or when all plugin settings are required to be loaded (which is a common pattern in Moodle plugins): https://github.com/catalyst/moodle-local_envbar/blob/MOODLE_405_STABLE/index.php#L34 
3. The code that this PR wants to remove does not do what it intends to do at present because it tries to set the tab of the settings.php page according to an id url param but there is only one settings.php page (the default one). All other tabs link to a page that isn't settings.php. Thus the settings.php page will always set to the default tab anyway when settings.php is accessed.

- What is the expected behavior after the change?

1. No change in the plugin's behaviour.
2. Behaviour of other plugins installed on a given site while this plugin is installed will change in some circumstances. E.g., local_envbar when accessing index.php will call the following line of code that ultimately triggers an error that the current PR tries to address but this error will no longer be thrown thus behaviour will change: https://github.com/catalyst/moodle-local_envbar/blob/MOODLE_405_STABLE/index.php#L34

---