### PR TITLE
bugfix: category trigger: do not display form elements twice

### DIFF
--- a/trigger/categories/lib.php
+++ b/trigger/categories/lib.php
@@ -144,7 +144,7 @@ class categories extends base_automatic {
      */
     public function extend_add_instance_form_definition_after_data($mform, $settings) {
         $type = $mform->getElementType('instancename');
-        if ($type ?? "" == "text") {
+        if (($type ?? "") != "text") {
             if (is_array($settings) && array_key_exists('categories', $settings)) {
                 $triggercategories = explode(",", $settings['categories']);
             } else {

--- a/trigger/categories/version.php
+++ b/trigger/categories/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2025050400;
+$plugin->version = 2025050400.01;
 $plugin->requires = 2022112800; // Requires Moodle 4.1+.
 $plugin->supported = [401, 405];
 $plugin->component = 'lifecycletrigger_categories';


### PR DESCRIPTION
> **Note:** Please fill out all relevant sections and remove irrelevant ones.
### 🔀 Purpose of this PR:

- [x] Fixes a bug
- [ ] Updates for a new Moodle version
- [ ] Adds a new feature of functionality
- [ ] Improves or enhances existing features
- [ ] Refactoring: restructures code for better performance or maintainability
- [ ] Testing: add missing or improve existing tests
- [ ] Miscellaneous: code cleaning (without functional changes), documentation, configuration, ...

---

### 📝 Description:

Please describe the purpose of this PR in a few sentences.

- What feature or bug does it address?
categorietrigger subplugin displays form elements twice in edit mode

- Why is this change or addition necessary?

- What is the expected behavior after the change?
Do not show form elements twice in edit mode

---

### 📋 Checklist

Please confirm the following (check all that apply):

- [ ] I have `phpunit` and/or `behat` tests that cover my changes or additions.
- [x] Code passes the code checker without errors and warnings.
- [x] Code passes the moodle-ci/cd pipeline on all supported Moodle versions or the ones the plugin supports.
- [x] Code does not have `var_dump()` or `var_export` or any other debugging statements (or commented out code) that
  should not appear on the productive branch.
- [x] Code only uses language strings instead of hard-coded strings.
- [ ] If there are changes in the database: I updated/created the necessary upgrade steps in `db/upgrade.php` and
  updated the `version.php`.
- [ ] If there are changes in javascript: I build new `.min` files with the `grunt amd` command.
- [ ] If it is a Moodle update PR: I read the release notes, updated the `version.php` and the `CHANGES.md`.
  I ran all tests thoroughly checking for errors. I checked if bootstrap had any changes/deprecations that require
  changes in the plugins UI.

---

### 🔍 Related Issues

- Related to #263

---

### 🧾📸🌐 Additional Information (like screenshots, documentation, links, etc.)

Any other relevant information.

---