### PR TITLE
Pr bugfix man and auto trigger

### DIFF
--- a/classes/local/table/interaction_remaining_table.php
+++ b/classes/local/table/interaction_remaining_table.php
@@ -82,7 +82,11 @@ class interaction_remaining_table extends interaction_table {
                 if (count($triggers) > 0) {
                     $processor = new \tool_lifecycle\processor();
                     $recordset = $processor->get_course_recordset($triggers);
-                    $this->trigger2courses[$tool->triggerid] = $recordset;
+                    $courses = [];
+                    foreach ($recordset as $element) {
+                        $courses[] = $element->id;
+                    }
+                    $this->trigger2courses[$tool->triggerid] = $courses;
                 }
             }
         }
@@ -170,7 +174,7 @@ class interaction_remaining_table extends interaction_table {
                 // Check if 'this' course is included in course set.
                 $found = false;
                 foreach ($this->trigger2courses[$tool->triggerid] as $element) {
-                    if ($row->courseid === $element->id) {
+                    if ($row->courseid === $element) {
                         // Course is included in course set of automatic trigger(s).
                         $found = true;
                         break;

--- a/tests/behat/trigger_combination.feature
+++ b/tests/behat/trigger_combination.feature
@@ -1,5 +1,5 @@
 @tool @tool_lifecycle @manual_trigger
-Feature: Combine triggers with and operation and test view and actions
+Feature: Combine triggers with 'and' operation and test view and actions
 
   Background:
     Given the following "users" exist:
@@ -31,6 +31,7 @@ Feature: Combine triggers with and operation and test view and actions
 
   @javascript
   Scenario: Combine manual trigger with automatic categories trigger (backup and course deletion)
+    # => category archive is excluded, so course ArchCourse shall not be deleted
     Given I log in as "admin"
     And I am on workflowdrafts page
     And I click on "Create new workflow" "link"


### PR DESCRIPTION
> **Note:** Please fill out all relevant sections and remove irrelevant ones.
### 🔀 Purpose of this PR:

- [x] Fixes a bug
- [ ] Updates for a new Moodle version
- [ ] Adds a new feature of functionality
- [x] Improves or enhances existing features
- [ ] Refactoring: restructures code for better performance or maintainability
- [ ] Testing: add missing or improve existing tests
- [ ] Miscellaneous: code cleaning (without functional changes), documentation, configuration, ...

---

### 📝 Description:

Please describe the purpose of this PR in a few sentences.

- What feature or bug does it address?
So far: You can combine a manual trigger with an automatic trigger but the automatic trigger is silently ignored when running the workflow. Only the manual trigger is executed.  

The pull request determines the course set of the automatic trigger (or triggers) and applies the manual trigger only to this course subset. 

- Why is this change or addition necessary?
It enables restricting a manual trigger to a course category by simply combining it with the category trigger. 
Of course the manual trigger can also be combined with other automatic triggers. 

- What is the expected behavior after the change?
When combining a manual trigger with an automatic trigger, the automatic trigger shall no longer be ignored. 

---

### 📋 Checklist

Please confirm the following (check all that apply):

- [x] I have `phpunit` and/or `behat` tests that cover my changes or additions.
- [x] Code passes the code checker without errors and warnings.
- [x] Code passes the moodle-ci/cd pipeline on all supported Moodle versions or the ones the plugin supports.
- [x] Code does not have `var_dump()` or `var_export` or any other debugging statements (or commented out code) that
  should not appear on the productive branch.
- [x] Code only uses language strings instead of hard-coded strings.
- [ ] If there are changes in the database: I updated/created the necessary upgrade steps in `db/upgrade.php` and
  updated the `version.php`.
- [ ] If there are changes in javascript: I build new `.min` files with the `grunt amd` command.
- [ ] If it is a Moodle update PR: I read the release notes, updated the `version.php` and the `CHANGES.md`.
  I ran all tests thoroughly checking for errors. I checked if bootstrap had any changes/deprecations that require
  changes in the plugins UI.

---

### 🔍 Related Issues

- Related to #

---

### 🧾📸🌐 Additional Information (like screenshots, documentation, links, etc.)

Any other relevant information.

Behat test scenario is added. 
Only and combination is code. OR combination can be replaced by multiple workflows and is less interesting.

---