### PR TITLE
Update plugin version for Moodle 4.5+  to 2026021745

### DIFF
--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@ defined('MOODLE_INTERNAL') || die;
 
 $plugin->component = 'tool_lifecycle';
 $plugin->maturity = MATURITY_STABLE;
-$plugin->version  = 2025050409;
+$plugin->version  = 2026021745;
 $plugin->requires = 2022112800; // Requires Moodle 4.1+.
 $plugin->supported = [405, 405];
 $plugin->release   = 'v4.5-r10';


### PR DESCRIPTION
The recent change in how releases are tagges and sorted on Moodle.org leads to an cannotdowngrade error, for all who just fechted the newest versions from moodle.org

https://moodle.org/plugins/tool_lifecycle/versions

4.5 Version from one week ago had the $plugin->version number. 
<img width="329" height="115" alt="grafik" src="https://github.com/user-attachments/assets/94427cc4-5467-4b22-b9c6-8f5e8de0a41f" />

Now it is lower:

<img width="329" height="115" alt="grafik" src="https://github.com/user-attachments/assets/98b0a5df-a481-4180-99d5-c20ebc9e1ca8" />

