### PR TITLE
Fix error table errortimecreated sorting

### DIFF
--- a/classes/local/table/process_errors_table.php
+++ b/classes/local/table/process_errors_table.php
@@ -89,7 +89,7 @@ class process_errors_table extends \table_sql {
         }
         $this->set_sql($fields, $from, $where, $params);
         $this->column_nosort = ['select', 'tools'];
-        $this->define_columns(['select', 'workflow', 'step', 'courseid', 'course', 'errortimecreated', 'error', 'tools']);
+        $this->define_columns(['select', 'workflow', 'step', 'courseid', 'course', 'errortimecreated', 'errormessage', 'tools']);
         $this->define_headers([
                 $OUTPUT->render(new \core\output\checkbox_toggleall('procerrors-table', true, [
                         'id' => 'select-all-procerrors',


### PR DESCRIPTION

### 🔀 Purpose of this PR:

- [X] Fixes a bug

---

### 📝 Description:

I noticed the following error when trying to sort the table on the `lifecycle/errors.php` page by the error time or error columns.

```
[Fri Mar 20 14:50:45.065714 2026] [proxy_fcgi:error] [pid 114611:tid 114626] [client XX:56934] AH01071: Got error 'PHP message: Default exception handler: Fehler beim Lesen der Datenbank Debug: Unknown column 'error' in 'ORDER BY'
SELECT
                c.id, c.fullname as course,
                w.id as workflowid, w.title as workflow,
                s.id as stepid, s.instancename as step,
               pe.id as errorid, pe.courseid, pe.errormessage, pe.errortrace, pe.errortimecreated
               FROM mdl_tool_lifecycle_proc_error pe LEFT JOIN mdl_tool_lifecycle_workflow w ON pe.workflowid = w.id LEFT JOIN mdl_tool_lifecycle_step s ON pe.workflowid = s.workflowid AND pe.stepindex = s.sortindex LEFT JOIN mdl_course c ON pe.courseid = c.id 
                WHERE TRUE AND w.id = ?
                ORDER BY errortime ASC, error ASC LIMIT 0, 100
                [array (\n  0 => '2',\n)]
                Error code: dmlreadexception
                * line 497 of /lib/dml/moodle_d', 
```

The table definition call should contain the names of the field in the database instead of the

---

### 📋 Checklist

Please confirm the following (check all that apply):

- [ ] Code passes the code checker without errors and warnings.
- [ ] Code passes the moodle-ci/cd pipeline on all supported Moodle versions or the ones the plugin supports.
---