### PR TITLE
Add 3 subplugins and amended pre-existing Step: coursedelete

### DIFF
--- a/classes/local/entity/process.php
+++ b/classes/local/entity/process.php
@@ -114,10 +114,23 @@ class process {
         }
 
         if (!$coursedeleted) {
-            $context = \context_course::instance($record->courseid);
+            /* Use IGNORE_MISSING so that if a course has been deleted outside of lifecycle
+            (e.g. manually or by a previous failed cron run) this never throws a
+            dml_missing_record_exception. Callers that need a valid context should check
+            that $process->context is not empty before proceeding */
+            $context = \context_course::instance($record->courseid, IGNORE_MISSING);
+            if ($context === false) {
+                debugging(
+                    'tool_lifecycle process::from_record: course ' . $record->courseid .
+                    ' has no context — treating as deleted.',
+                    DEBUG_DEVELOPER
+                );
+                $context = '';
+            }
         } else {
-            $context = "";
+            $context = '';
         }
+
         $instance = new self($record->id,
                 $record->workflowid,
                 $record->courseid,

--- a/classes/local/manager/process_manager.php
+++ b/classes/local/manager/process_manager.php
@@ -176,9 +176,13 @@ class process_manager {
     }
 
     /**
-     * Returns all processes for given workflow id
+     * Returns all processes for given workflow id.
+     * Orphaned process records (where the course no longer exists) are detected here
+     * and moved to the proc_error table rather than being returned, preventing a fatal
+     * dml_missing_record_exception when lifecycle later tries to load the course context
+     * (e.g. during abortprocesses()).
      * @param int $workflowid id of the workflow
-     * @return array of proccesses initiated by specifed workflow id
+     * @return array of processes initiated by specified workflow id
      * @throws \dml_exception
      */
     public static function get_processes_by_workflow($workflowid) {
@@ -186,6 +190,23 @@ class process_manager {
         $records = $DB->get_records('tool_lifecycle_process', ['workflowid' => $workflowid]);
         $processes = [];
         foreach ($records as $record) {
+            /* 
+            Detect orphaned process records pointing to courses that no longer exist
+            and route them to the error table, consistent with how get_processes() handles
+            the same situation. Without this guard,= abortprocesses() could fatally crash when
+            process::from_record() calls context_course::instance() on a deleted course 
+            */
+            if (!$DB->record_exists('course', ['id' => $record->courseid])) {
+                debugging(
+                    'tool_lifecycle get_processes_by_workflow: course ' . $record->courseid .
+                    ' no longer exists — moving process ' . $record->id . ' to error table.',
+                    DEBUG_DEVELOPER
+                );
+                $process = process::from_record($record, true);
+                $e = new \Exception(get_string('process_withnotexistingcourse', 'tool_lifecycle'));
+                self::insert_process_error($process, $e);
+                continue;
+            }
             $processes[] = process::from_record($record);
         }
         return $processes;

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -435,7 +435,6 @@ function xmldb_tool_lifecycle_upgrade($oldversion) {
         }
 
         // Lifecycle savepoint reached.
-
         upgrade_plugin_savepoint(true, 2019082200, 'tool', 'lifecycle');
     }
 
@@ -448,7 +447,6 @@ function xmldb_tool_lifecycle_upgrade($oldversion) {
         set_config('duration', $duration, 'tool_lifecycle');
 
         // Lifecycle savepoint reached.
-
         upgrade_plugin_savepoint(true, 2019082300, 'tool', 'lifecycle');
     }
 
@@ -613,6 +611,7 @@ function xmldb_tool_lifecycle_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2025050405, 'tool', 'lifecycle');
 
     }
+
     if ($oldversion < 2025102302) {
         $table = new xmldb_table('tool_lifecycle_workflow');
 
@@ -713,6 +712,27 @@ function xmldb_tool_lifecycle_upgrade($oldversion) {
 
         // Lifecycle savepoint reached.
         upgrade_plugin_savepoint(true, 2026012003, 'tool', 'lifecycle');
+    }
+
+    if ($oldversion < 2026012004) {
+
+        // Lifecycle savepoint reached.
+        upgrade_plugin_savepoint(true, 2026012004, 'tool', 'lifecycle');
+    }
+
+    if ($oldversion < 2026012005) {
+
+        // Remove orphaned process records pointing to courses that no longer exist.
+        // These cause a fatal dml_missing_record_exception in abortprocesses() when
+        // lifecycle tries to load the course context via process::from_record().
+        // This mirrors the cleanup already done at upgrade 2020091800 but uses a
+        // direct DELETE for efficiency and to avoid calling abort_process() on records
+        // whose course context cannot be loaded.
+        $DB->execute('DELETE FROM {tool_lifecycle_process}
+                      WHERE courseid NOT IN (SELECT id FROM {course})');
+
+        // Lifecycle savepoint reached.
+        upgrade_plugin_savepoint(true, 2026012005, 'tool', 'lifecycle');
     }
 
     return true;

--- a/errors.php
+++ b/errors.php
@@ -50,8 +50,13 @@ if ($action) {
     if ($action == 'proceed') {
         foreach ($ids as $id) {
             if ($courseid = $DB->get_field('tool_lifecycle_proc_error', 'courseid', ['id' => $id])) {
-                $course = get_course($courseid);
-                $coursename = get_course_display_name_for_list($course);
+                // Course may have been deleted — guard against get_course() throwing.
+                try {
+                    $course = get_course($courseid);
+                    $coursename = get_course_display_name_for_list($course);
+                } catch (\dml_missing_record_exception $e) {
+                    $coursename = get_string('coursenotfound', 'tool_lifecycle') . ' (ID: ' . $courseid . ')';
+                }
             } else {
                 $coursename = get_string('coursenotfound', 'tool_lifecycle');
             }
@@ -67,8 +72,13 @@ if ($action) {
     } else if ($action == 'rollback') {
         foreach ($ids as $id) {
             if ($courseid = $DB->get_field('tool_lifecycle_proc_error', 'courseid', ['id' => $id])) {
-                $course = get_course($courseid);
-                $coursename = get_course_display_name_for_list($course);
+                // Course may have been deleted — guard against get_course() throwing.
+                try {
+                    $course = get_course($courseid);
+                    $coursename = get_course_display_name_for_list($course);
+                } catch (\dml_missing_record_exception $e) {
+                    $coursename = get_string('coursenotfound', 'tool_lifecycle') . ' (ID: ' . $courseid . ')';
+                }
             } else {
                 $coursename = get_string('coursenotfound', 'tool_lifecycle');
             }

--- a/step/uclcontextfreeze/lang/en/lifecyclestep_uclcontextfreeze.php
+++ b/step/uclcontextfreeze/lang/en/lifecyclestep_uclcontextfreeze.php
@@ -1,0 +1,29 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Lang strings for delete course step
+ *
+ * @package lifecyclestep_uclcontextfreeze
+ * @copyright  2025 UCL
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+$string['stepname'] = 'Archive/Freeze course step';
+$string['plugindescription'] = 'Calls UCLs contextfreeze (block) to archive courses';
+$string['pluginname'] = 'UCL contextfreeze';
+$string['privacy:metadata'] = 'This subplugin does not store any personal data.';
+

--- a/step/uclcontextfreeze/lib.php
+++ b/step/uclcontextfreeze/lib.php
@@ -1,0 +1,83 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+ /**
+  * Step subplugin to freeze a course context using UCL block_lifecycle manager.
+  *
+  * @package    lifecyclestep_uclcontextfreeze
+  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+  */
+
+namespace tool_lifecycle\step;
+
+use stdClass;
+use tool_lifecycle\local\response\step_response;
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once(__DIR__ . '/../lib.php');
+
+/**
+ * Step subplugin to freeze a course context using UCL block_lifecycle.
+ *
+ * @package    lifecyclestep_uclcontextfreeze
+ */
+class uclcontextfreeze extends libbase {
+
+    /**
+     * Processes the course and returns a response.
+     *
+     * @param int $processid of the respective process.
+     * @param int $instanceid of the step instance.
+     * @param stdClass $course to be processed.
+     * @return step_response
+     */
+    public function process_course($processid, $instanceid, $course) {
+
+        if (!class_exists('\block_lifecycle\manager')) {
+            return step_response::rollback();
+        }
+
+        try {
+            \block_lifecycle\manager::freeze_course((int)$course->id);
+        } catch (\Exception $e) {
+            return step_response::rollback();
+        }
+
+        return step_response::proceed();
+    }
+
+    /**
+     * Processes the course in status waiting and returns a response.
+     *
+     * @param int $processid
+     * @param int $instanceid
+     * @param stdClass $course
+     * @return step_response
+     */
+    public function process_waiting_course($processid, $instanceid, $course) {
+        return $this->process_course($processid, $instanceid, $course);
+    }
+
+    /**
+     * The return value should be equivalent with the name of the subplugin folder.
+     *
+     * @return string
+     */
+    public function get_subpluginname() {
+        return 'uclcontextfreeze';
+    }
+}

--- a/step/uclcontextfreeze/version.php
+++ b/step/uclcontextfreeze/version.php
@@ -1,0 +1,14 @@
+<?php
+defined('MOODLE_INTERNAL') || die();
+
+$plugin->component = 'lifecyclestep_uclcontextfreeze';
+$plugin->version   = 2025102300;
+$plugin->requires  = 2022112800; // Requires Moodle 4.1+.
+$plugin->maturity  = MATURITY_STABLE;
+$plugin->release   = '0.1';
+
+// Requires UCL's lifecycle bloxk (so the manager class exists)
+$plugin->dependencies = [
+    'block_lifecycle' => ANY_VERSION,
+];
+

--- a/trigger/coursedelete/classes/privacy/provider.php
+++ b/trigger/coursedelete/classes/privacy/provider.php
@@ -1,0 +1,39 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace lifecycletrigger_coursedelete\privacy;
+
+use core_privacy\local\metadata\null_provider;
+
+/**
+ * Privacy subsystem implementation for lifecycletrigger_coursefreeze.
+ *
+ * @package     lifecycletrigger_coursefreeze
+ * @copyright   2025 Gifty Wanzola (ccaewan)
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class provider implements null_provider {
+
+    /**
+     * Get the language string identifier with the component's language
+     * file to explain why this plugin stores no data.
+     *
+     * @return string
+     */
+    public static function get_reason(): string {
+        return 'privacy:metadata';
+    }
+}

--- a/trigger/coursedelete/lang/en/lifecycletrigger_coursedelete.php
+++ b/trigger/coursedelete/lang/en/lifecycletrigger_coursedelete.php
@@ -1,0 +1,45 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Lang strings for course freeze trigger
+ *
+ * @package lifecycletrigger_coursedelete
+ * @copyright  2025 Gifty (ccaewan)
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+ $string['pluginname'] = 'Select long-term archived courses for deletion';
+ // Description shown on the workflow configuration page.
+
+ $string['plugindescription'] =
+    'Selects courses that have been archived (frozen), have not been accessed for a prolonged period, '
+    . 'and were created sufficiently long ago. These courses are considered end-of-life and may be '
+    . 'safely removed using a delete step in the workflow.';
+
+ $string['inactivitydelay'] = 'Last access threshold';
+ $string['inactivitydelay_help'] =
+    'Only delete courses where the most recent user activity is older than this period. '
+    . 'Set to 48 months by default to target courses with no access for at least 4 years.';
+
+ $string['creationdelay'] = 'Minimum course age';
+
+ $string['creationdelay_help'] =
+    'The minimum age of a course based on its creation date. '
+    . 'Courses created more recently than this threshold will not be selected for deletion.'
+    . 'Set to 60 months by default to target courses with older than at least 5 years.';
+
+ $string['privacy:metadata'] = 'The Course deletion trigger does not store or process personal data.';

--- a/trigger/coursedelete/lib.php
+++ b/trigger/coursedelete/lib.php
@@ -1,0 +1,154 @@
+<?php
+ // This file is part of Moodle - http://moodle.org/
+ //
+ // Moodle is free software: you can redistribute it and/or modify
+ // it under the terms of the GNU General Public License as published by
+ // the Free Software Foundation, either version 3 of the License, or
+ // (at your option) any later version.
+ //
+ // Moodle is distributed in the hope that it will be useful,
+ // but WITHOUT ANY WARRANTY; without even the implied warranty of
+ // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ // GNU General Public License for more details.
+ //
+ // You should have received a copy of the GNU General Public License
+ // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+ /**
+  * Trigger subplugin to delete frozen courses based on long inactivity + age.
+  *
+  * @package lifecycletrigger_coursedelete
+  * @copyright  2025
+  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+  */
+ namespace tool_lifecycle\trigger;
+
+ use tool_lifecycle\local\manager\settings_manager;
+ use tool_lifecycle\local\response\trigger_response;
+ use tool_lifecycle\settings_type;
+ use tool_lifecycle\trigger\instance_setting;
+
+ defined('MOODLE_INTERNAL') || die();
+ require_once(__DIR__ . '/../lib.php');
+
+ /**
+  * Class which implements a trigger for deleting frozen courses.
+  *
+  * Logic (workaround while no "frozen since" timestamp exists):
+  *  - Course context is locked (frozen): {context}.locked = 1 for course contextlevel 50
+  *  - Last access (enrolled users) older than inactivitydelay (default 48 months)
+  *  - Course creation older than creationdelay (default 60 months)
+  */
+ class coursedelete extends base_automatic {
+
+     public function check_course($course, $triggerid) {
+         return trigger_response::trigger();
+     }
+
+     /**
+      * Instance settings for this trigger.
+      *
+      * @return instance_setting[]
+      */
+     public function instance_settings() {
+         return [
+             // Last access must be older than this (default 48 months).
+             new instance_setting('inactivitydelay', PARAM_INT),
+
+             // Course creation must be older than this (default 60 months).
+             new instance_setting('creationdelay', PARAM_INT),
+         ];
+     }
+
+     /**
+      * Returns the WHERE clause and params selecting courses to be deleted.
+      *
+      * @param int $triggerid
+      * @return array [string $where, array $params]
+      * @throws \coding_exception
+      * @throws \dml_exception
+      */
+     public function get_course_recordset_where($triggerid) {
+         // Load instance settings.
+         $settings = settings_manager::get_settings($triggerid, settings_type::TRIGGER);
+
+         // Defaults (approx months as 365-day years for now):
+         // - 48 months ≈ 4 years
+         // - 60 months ≈ 5 years
+         $inactivitydelay = isset($settings['inactivitydelay']) ? (int)$settings['inactivitydelay'] : (4 * 365 * DAYSECS);
+         $creationdelay   = isset($settings['creationdelay'])   ? (int)$settings['creationdelay']   : (5 * 365 * DAYSECS);
+
+         $now = time();
+         $lastaccessthreshold = $now - $inactivitydelay;
+         $creationthreshold   = $now - $creationdelay;
+
+         // Frozen courses: course context locked
+         // Inactive courses: most recent recorded course access is older than threshold
+         // Old courses: timecreated older than threshold
+         $where = "c.timecreated < :creationthreshold
+                   AND EXISTS (
+                         SELECT 1
+                           FROM {context} ctx
+                          WHERE ctx.contextlevel = 50
+                            AND ctx.instanceid = c.id
+                            AND ctx.locked = 1
+                   )
+                   AND c.id IN (
+                         SELECT la.courseid
+                           FROM {user_lastaccess} la
+                          GROUP BY la.courseid
+                          HAVING MAX(la.timeaccess) < :lastaccessthreshold
+                   )";
+      
+
+         $params = [
+             'creationthreshold'   => $creationthreshold,
+             'lastaccessthreshold' => $lastaccessthreshold,
+         ];
+
+         return [$where, $params];
+     }
+
+     /**
+      * Add instance settings elements to the add-instance form.
+      *
+      * @param \MoodleQuickForm $mform
+      * @return void
+      * @throws \coding_exception
+      */
+     public function extend_add_instance_form_definition($mform) {
+
+         $elementname = 'inactivitydelay';
+         $mform->addElement('duration', $elementname, get_string($elementname, 'lifecycletrigger_coursedelete'));
+         $mform->addHelpButton($elementname, $elementname, 'lifecycletrigger_coursedelete');
+         $mform->setDefault($elementname, 4 * 365 * DAYSECS); // ~48 months.
+
+         $elementname = 'creationdelay';
+         $mform->addElement('duration', $elementname, get_string($elementname, 'lifecycletrigger_coursedelete'));
+         $mform->addHelpButton($elementname, $elementname, 'lifecycletrigger_coursedelete');
+         $mform->setDefault($elementname, 5 * 365 * DAYSECS); // ~60 months.
+     }
+
+     /**
+      * After data is loaded, set defaults from existing settings if present.
+      *
+      * @param \MoodleQuickForm $mform
+      * @param array $settings
+      * @return void
+      */
+     public function extend_add_instance_form_definition_after_data($mform, $settings) {
+         if (!is_array($settings)) {
+             return;
+         }
+         if (array_key_exists('inactivitydelay', $settings)) {
+             $mform->setDefault('inactivitydelay', $settings['inactivitydelay']);
+         }
+         if (array_key_exists('creationdelay', $settings)) {
+             $mform->setDefault('creationdelay', $settings['creationdelay']);
+         }
+     }
+
+     public function get_subpluginname() {
+         return 'coursedelete';
+     }
+ }

--- a/trigger/coursedelete/lib.php
+++ b/trigger/coursedelete/lib.php
@@ -1,154 +1,165 @@
 <?php
- // This file is part of Moodle - http://moodle.org/
- //
- // Moodle is free software: you can redistribute it and/or modify
- // it under the terms of the GNU General Public License as published by
- // the Free Software Foundation, either version 3 of the License, or
- // (at your option) any later version.
- //
- // Moodle is distributed in the hope that it will be useful,
- // but WITHOUT ANY WARRANTY; without even the implied warranty of
- // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- // GNU General Public License for more details.
- //
- // You should have received a copy of the GNU General Public License
- // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
- /**
-  * Trigger subplugin to delete frozen courses based on long inactivity + age.
-  *
-  * @package lifecycletrigger_coursedelete
-  * @copyright  2025
-  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
-  */
- namespace tool_lifecycle\trigger;
+/**
+ * Trigger subplugin to delete frozen courses based on long inactivity + age.
+ *
+ * @package lifecycletrigger_coursedelete
+ * @copyright  2025
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+namespace tool_lifecycle\trigger;
 
- use tool_lifecycle\local\manager\settings_manager;
- use tool_lifecycle\local\response\trigger_response;
- use tool_lifecycle\settings_type;
- use tool_lifecycle\trigger\instance_setting;
+use tool_lifecycle\local\manager\settings_manager;
+use tool_lifecycle\local\response\trigger_response;
+use tool_lifecycle\settings_type;
+use tool_lifecycle\trigger\instance_setting;
 
- defined('MOODLE_INTERNAL') || die();
- require_once(__DIR__ . '/../lib.php');
+defined('MOODLE_INTERNAL') || die();
+require_once(__DIR__ . '/../lib.php');
 
- /**
-  * Class which implements a trigger for deleting frozen courses.
-  *
-  * Logic (workaround while no "frozen since" timestamp exists):
-  *  - Course context is locked (frozen): {context}.locked = 1 for course contextlevel 50
-  *  - Last access (enrolled users) older than inactivitydelay (default 48 months)
-  *  - Course creation older than creationdelay (default 60 months)
-  */
- class coursedelete extends base_automatic {
+/**
+ * Class which implements a trigger for deleting frozen courses.
+ *
+ * Logic:
+ *  - Course context is locked (frozen): {context}.locked = 1 for course contextlevel 50
+ *  - Last access (enrolled users) older than inactivitydelay (default 48 months),
+ *    OR course has never been accessed at all (no rows in user_lastaccess)
+ *  - Course creation older than creationdelay (default 60 months)
+ */
+class coursedelete extends base_automatic {
 
-     public function check_course($course, $triggerid) {
-         return trigger_response::trigger();
-     }
+    public function check_course($course, $triggerid) {
+        return trigger_response::trigger();
+    }
 
-     /**
-      * Instance settings for this trigger.
-      *
-      * @return instance_setting[]
-      */
-     public function instance_settings() {
-         return [
-             // Last access must be older than this (default 48 months).
-             new instance_setting('inactivitydelay', PARAM_INT),
+    /**
+     * Instance settings for this trigger.
+     *
+     * @return instance_setting[]
+     */
+    public function instance_settings() {
+        return [
+            // Last access must be older than this (default 48 months).
+            new instance_setting('inactivitydelay', PARAM_INT),
 
-             // Course creation must be older than this (default 60 months).
-             new instance_setting('creationdelay', PARAM_INT),
-         ];
-     }
+            // Course creation must be older than this (default 60 months).
+            new instance_setting('creationdelay', PARAM_INT),
+        ];
+    }
 
-     /**
-      * Returns the WHERE clause and params selecting courses to be deleted.
-      *
-      * @param int $triggerid
-      * @return array [string $where, array $params]
-      * @throws \coding_exception
-      * @throws \dml_exception
-      */
-     public function get_course_recordset_where($triggerid) {
-         // Load instance settings.
-         $settings = settings_manager::get_settings($triggerid, settings_type::TRIGGER);
+    /**
+     * Returns the WHERE clause and params selecting courses to be deleted.
+     *
+     * Matches frozen courses that are either:
+     *  - Old enough AND have never been accessed (no user_lastaccess rows), OR
+     *  - Old enough AND last access is older than inactivitydelay
+     *
+     * This mirrors the same NOT EXISTS / OR EXISTS pattern used in the
+     * coursefreeze trigger so that courses with zero access records are
+     * correctly included rather than silently excluded.
+     *
+     * @param int $triggerid
+     * @return array [string $where, array $params]
+     * @throws \coding_exception
+     * @throws \dml_exception
+     */
+    public function get_course_recordset_where($triggerid) {
+        $settings = settings_manager::get_settings($triggerid, settings_type::TRIGGER);
 
-         // Defaults (approx months as 365-day years for now):
-         // - 48 months ≈ 4 years
-         // - 60 months ≈ 5 years
-         $inactivitydelay = isset($settings['inactivitydelay']) ? (int)$settings['inactivitydelay'] : (4 * 365 * DAYSECS);
-         $creationdelay   = isset($settings['creationdelay'])   ? (int)$settings['creationdelay']   : (5 * 365 * DAYSECS);
+        $inactivitydelay = isset($settings['inactivitydelay']) ? (int)$settings['inactivitydelay'] : (4 * 365 * DAYSECS);
+        $creationdelay   = isset($settings['creationdelay'])   ? (int)$settings['creationdelay']   : (5 * 365 * DAYSECS);
 
-         $now = time();
-         $lastaccessthreshold = $now - $inactivitydelay;
-         $creationthreshold   = $now - $creationdelay;
+        $now = time();
+        $lastaccessthreshold = $now - $inactivitydelay;
+        $creationthreshold   = $now - $creationdelay;
+     // Include NOT EXISTS / OR EXISTS to prevent silently excluded courses (enroled users without any LA records)
+        $where = "c.id <> 1
+                  AND c.timecreated < :creationthreshold
+                  AND EXISTS (
+                        SELECT 1
+                          FROM {context} ctx
+                         WHERE ctx.contextlevel = 50
+                           AND ctx.instanceid = c.id
+                           AND ctx.locked = 1
+                  )
+                  AND (
+                        NOT EXISTS (
+                            SELECT 1
+                              FROM {user_lastaccess} la
+                             WHERE la.courseid = c.id
+                        )
+                        OR
+                        EXISTS (
+                            SELECT 1
+                              FROM {user_lastaccess} la
+                             WHERE la.courseid = c.id
+                             GROUP BY la.courseid
+                            HAVING MAX(la.timeaccess) < :lastaccessthreshold
+                        )
+                  )";
 
-         // Frozen courses: course context locked
-         // Inactive courses: most recent recorded course access is older than threshold
-         // Old courses: timecreated older than threshold
-         $where = "c.timecreated < :creationthreshold
-                   AND EXISTS (
-                         SELECT 1
-                           FROM {context} ctx
-                          WHERE ctx.contextlevel = 50
-                            AND ctx.instanceid = c.id
-                            AND ctx.locked = 1
-                   )
-                   AND c.id IN (
-                         SELECT la.courseid
-                           FROM {user_lastaccess} la
-                          GROUP BY la.courseid
-                          HAVING MAX(la.timeaccess) < :lastaccessthreshold
-                   )";
-      
+        $params = [
+            'creationthreshold'   => $creationthreshold,
+            'lastaccessthreshold' => $lastaccessthreshold,
+        ];
 
-         $params = [
-             'creationthreshold'   => $creationthreshold,
-             'lastaccessthreshold' => $lastaccessthreshold,
-         ];
+        return [$where, $params];
+    }
 
-         return [$where, $params];
-     }
+    /**
+     * Add instance settings elements to the add-instance form.
+     *
+     * @param \MoodleQuickForm $mform
+     * @return void
+     * @throws \coding_exception
+     */
+    public function extend_add_instance_form_definition($mform) {
 
-     /**
-      * Add instance settings elements to the add-instance form.
-      *
-      * @param \MoodleQuickForm $mform
-      * @return void
-      * @throws \coding_exception
-      */
-     public function extend_add_instance_form_definition($mform) {
+        $elementname = 'inactivitydelay';
+        $mform->addElement('duration', $elementname, get_string($elementname, 'lifecycletrigger_coursedelete'));
+        $mform->addHelpButton($elementname, $elementname, 'lifecycletrigger_coursedelete');
+        $mform->setDefault($elementname, 4 * 365 * DAYSECS); // ~48 months.
 
-         $elementname = 'inactivitydelay';
-         $mform->addElement('duration', $elementname, get_string($elementname, 'lifecycletrigger_coursedelete'));
-         $mform->addHelpButton($elementname, $elementname, 'lifecycletrigger_coursedelete');
-         $mform->setDefault($elementname, 4 * 365 * DAYSECS); // ~48 months.
+        $elementname = 'creationdelay';
+        $mform->addElement('duration', $elementname, get_string($elementname, 'lifecycletrigger_coursedelete'));
+        $mform->addHelpButton($elementname, $elementname, 'lifecycletrigger_coursedelete');
+        $mform->setDefault($elementname, 5 * 365 * DAYSECS); // ~60 months.
+    }
 
-         $elementname = 'creationdelay';
-         $mform->addElement('duration', $elementname, get_string($elementname, 'lifecycletrigger_coursedelete'));
-         $mform->addHelpButton($elementname, $elementname, 'lifecycletrigger_coursedelete');
-         $mform->setDefault($elementname, 5 * 365 * DAYSECS); // ~60 months.
-     }
+    /**
+     * After data is loaded, set defaults from existing settings if present.
+     *
+     * @param \MoodleQuickForm $mform
+     * @param array $settings
+     * @return void
+     */
+    public function extend_add_instance_form_definition_after_data($mform, $settings) {
+        if (!is_array($settings)) {
+            return;
+        }
+        if (array_key_exists('inactivitydelay', $settings)) {
+            $mform->setDefault('inactivitydelay', $settings['inactivitydelay']);
+        }
+        if (array_key_exists('creationdelay', $settings)) {
+            $mform->setDefault('creationdelay', $settings['creationdelay']);
+        }
+    }
 
-     /**
-      * After data is loaded, set defaults from existing settings if present.
-      *
-      * @param \MoodleQuickForm $mform
-      * @param array $settings
-      * @return void
-      */
-     public function extend_add_instance_form_definition_after_data($mform, $settings) {
-         if (!is_array($settings)) {
-             return;
-         }
-         if (array_key_exists('inactivitydelay', $settings)) {
-             $mform->setDefault('inactivitydelay', $settings['inactivitydelay']);
-         }
-         if (array_key_exists('creationdelay', $settings)) {
-             $mform->setDefault('creationdelay', $settings['creationdelay']);
-         }
-     }
-
-     public function get_subpluginname() {
-         return 'coursedelete';
-     }
- }
+    public function get_subpluginname() {
+        return 'coursedelete';
+    }
+}

--- a/trigger/coursedelete/version.php
+++ b/trigger/coursedelete/version.php
@@ -1,0 +1,32 @@
+<?php
+// This file is part of Moodle - http://moodle.org/.
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Version info for lifecycle deletion trigger.
+ *
+ * @package     lifecycletrigger_coursedelete
+ * @copyright   2025 Gifty Wanzola (ccaewan)
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$plugin->version   = 2025121802;
+$plugin->component = 'lifecycletrigger_coursedelete';
+$plugin->maturity = MATURITY_STABLE;
+$plugin->requires = 2022112800; // Requires Moodle 4.1+.
+$plugin->supported = [405, 500];
+$plugin->release   = 'v5.0-r1';

--- a/trigger/coursefreeze/classes/privacy/provider.php
+++ b/trigger/coursefreeze/classes/privacy/provider.php
@@ -1,0 +1,39 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace lifecycletrigger_lastaccess\privacy;
+
+use core_privacy\local\metadata\null_provider;
+
+/**
+ * Privacy subsystem implementation for lifecycletrigger_lastaccess.
+ *
+ * @package     lifecycletrigger_lastaccess
+ * @copyright   2023 Justus Dieckmann WWU Münster
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class provider implements null_provider {
+
+    /**
+     * Get the language string identifier with the component's language
+     * file to explain why this plugin stores no data.
+     *
+     * @return string
+     */
+    public static function get_reason(): string {
+        return 'privacy:metadata';
+    }
+}

--- a/trigger/coursefreeze/lang/en/lifecycletrigger_coursefreeze.php
+++ b/trigger/coursefreeze/lang/en/lifecycletrigger_coursefreeze.php
@@ -1,0 +1,57 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Lang strings for course freeze trigger
+ *
+ * @package lifecycletrigger_coursefreeze
+ * @copyright  2025 Gifty (ccaewan)
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+
+// Short name shown in the trigger dropdown
+$string['pluginname'] = 'Select courses to archive';
+
+
+// Description shown on the workflow config page
+
+$string['plugindescription'] =
+    'Selects courses for archiving based on how long ago they were last accessed '
+    . 'and when they were created. Only courses that are older than both thresholds '
+    . 'will be passed to the next step.';
+
+
+// Last access threshold setting
+
+$string['lastaccessdelay'] = 'Time since last access';
+$string['lastaccessdelay_help'] =
+    'Only include courses where the most recent user activity is older than this period. '
+    . 'For example, set this to 12 months to target courses with no access for at least 1 year.';
+
+
+// Creation date setting
+
+$string['creationdelay'] = 'Course age';
+$string['creationdelay_help'] =
+    'Only include courses that were created earlier than this period. '
+    . 'For example, set this to 24 months so that only courses at least 2 years old are selected.';
+
+
+// Privacy
+
+$string['privacy:metadata'] =
+    'The Course freeze trigger does not store any personal data.';

--- a/trigger/coursefreeze/lib.php
+++ b/trigger/coursefreeze/lib.php
@@ -1,0 +1,185 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Interface for the subplugintype trigger
+ * It has to be implemented by all subplugins.
+ *
+ * @package lifecycletrigger_coursefreeze
+ * @copyright  2025 Gifty Wanzola (ccaewan)
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace tool_lifecycle\trigger;
+
+use tool_lifecycle\local\manager\settings_manager;
+use tool_lifecycle\local\response\trigger_response;
+use tool_lifecycle\settings_type;
+use tool_lifecycle\trigger\instance_setting;
+
+
+defined('MOODLE_INTERNAL') || die();
+require_once(__DIR__ . '/../lib.php');
+
+/**
+ * Class which implements the trigger for freezing courses.
+ *
+ * @package lifecycletrigger_coursefreeze
+ */
+class coursefreeze extends base_automatic {
+    /**
+     * If check_course_code() returns true, code to check the given course is placed here
+     * @param \stdClass $course
+     * @param int $triggerid
+     * @return trigger_response
+     */
+    public function check_course($course, $triggerid) {
+        // Every decision is already in the where statement.
+        return trigger_response::trigger();
+    }
+
+/**
+ * Instance settings for this trigger.
+ *
+ * @return instance_setting[]
+ */
+public function instance_settings() {
+    return [
+        // Last access must be older than this (12 months)
+        new instance_setting('lastaccessdelay', PARAM_INT),
+
+        // Course creation must be older than this (24 months)
+        new instance_setting('creationdelay', PARAM_INT),
+    ];
+}
+
+    /**
+     * Returns the where statement for all courses that should be triggered,
+     * meaning timestamp of the course freeze / interaction with this course is older than delay
+     * (only counting interactions of users who are enrolled in the course)
+     *
+     * @param int $triggerid  id of the trigger instance.
+     * @return string[]
+     * @throws \coding_exception
+     * @throws \dml_exception
+     */
+    public function get_course_recordset_where($triggerid) {
+        global $DB;
+
+        // Get trigger settings.
+        $settings = settings_manager::get_settings($triggerid, settings_type::TRIGGER);
+
+        // Fallback defaults if not set.
+        $lastaccessdelay = isset($settings['lastaccessdelay']) ? $settings['lastaccessdelay'] : DAYSECS * 365;        // 12 months.
+        $creationdelay   = isset($settings['creationdelay'])   ? $settings['creationdelay']   : DAYSECS * 365 * 2;    // 24 months.
+
+        $now = time();
+        $lastaccessthreshold = $now - $lastaccessdelay;
+        $creationthreshold   = $now - $creationdelay;
+
+        // Only courses that:
+        //  - have last access older than lastaccessthreshold
+        // or have never been accessed
+        //  - AND were created before creationthreshold
+        // not including the front page course
+        $where = 'c.id <> 1
+                  AND c.timecreated < :creationthreshold
+                  AND EXISTS (
+                        SELECT 1
+                          FROM {context} ctx
+                         WHERE ctx.contextlevel = 50
+                           AND ctx.instanceid = c.id
+                           AND ctx.locked = 0
+                  )
+                  AND (
+                        NOT EXISTS (
+                            SELECT 1
+                              FROM {user_lastaccess} la
+                             WHERE la.courseid = c.id
+                        )
+                        OR
+                        EXISTS (
+                            SELECT 1
+                              FROM {user_lastaccess} la
+                             WHERE la.courseid = c.id
+                             GROUP BY la.courseid
+                            HAVING MAX(la.timeaccess) < :lastaccessthreshold
+                        )
+                  )';
+
+        $params = [
+            'creationthreshold'   => $creationthreshold,
+            'lastaccessthreshold' => $lastaccessthreshold,
+        ];
+
+        return [$where, $params];
+    }
+
+
+    /**
+     * Add elements to add instance form
+     *
+     * @param \MoodleQuickForm $mform
+     * @return void
+     * @throws \coding_exception
+     */
+    public function extend_add_instance_form_definition($mform) {
+
+        // Check last access
+        $elementname = 'lastaccessdelay';
+        $mform->addElement('duration', $elementname,
+            get_string($elementname, 'lifecycletrigger_coursefreeze'));
+        $mform->addHelpButton($elementname, $elementname, 'lifecycletrigger_coursefreeze');
+        $mform->setDefault($elementname, DAYSECS * 365); // default = 12 months
+
+
+        // Check course creation age.
+        $elementname = 'creationdelay';
+        $mform->addElement('duration', $elementname,
+            get_string($elementname, 'lifecycletrigger_coursefreeze'));
+        $mform->addHelpButton($elementname, $elementname, 'lifecycletrigger_coursefreeze');
+        $mform->setDefault($elementname, DAYSECS * 365 * 2); // default = 24 months
+    }
+
+
+    /**
+     * Extend add instance form
+     *
+     * @param \MoodleQuickForm $mform
+     * @param array $settings
+     * @return void
+     */
+    public function extend_add_instance_form_definition_after_data($mform, $settings) {
+        if (is_array($settings)) {
+            if (array_key_exists('lastaccessdelay', $settings)) {
+                $mform->setDefault('lastaccessdelay', $settings['lastaccessdelay']);
+            }
+            if (array_key_exists('creationdelay', $settings)) {
+                $mform->setDefault('creationdelay', $settings['creationdelay']);
+            }
+        }
+    }
+
+    /**
+     * Return subplugin name
+     *
+     * @return string
+     */
+    public function get_subpluginname() {
+        return 'coursefreeze';
+    }
+
+}

--- a/trigger/coursefreeze/version.php
+++ b/trigger/coursefreeze/version.php
@@ -1,0 +1,32 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Life Cycle course freeze Trigger
+ *
+ * @package lifecycletrigger_coursefreeze
+ * @copyright  2025 Gifty (ccaewan)
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die;
+
+$plugin->component = 'lifecycletrigger_coursefreeze';
+$plugin->maturity = MATURITY_STABLE;
+$plugin->version  = 2025103000;
+$plugin->requires = 2022112800; // Requires Moodle 4.1+.
+$plugin->supported = [405, 500];
+$plugin->release   = 'v5.0-r1';

--- a/trigger/customfieldsemester/version.php
+++ b/trigger/customfieldsemester/version.php
@@ -32,5 +32,5 @@ $plugin->requires = 2024100700; // Requires Moodle 4.5+.
 $plugin->supported = [405, 501];
 $plugin->release   = 'v5.1-r5';
 
-// $plugin->dependencies = ['tool_lifecycle' => 2025050403,
-        // 'customfield_semester' => 2025043001, ];
+$plugin->dependencies = ['tool_lifecycle' => 2025050403,
+        'customfield_semester' => 2025043001, ];

--- a/trigger/customfieldsemester/version.php
+++ b/trigger/customfieldsemester/version.php
@@ -32,5 +32,5 @@ $plugin->requires = 2024100700; // Requires Moodle 4.5+.
 $plugin->supported = [405, 501];
 $plugin->release   = 'v5.1-r5';
 
-$plugin->dependencies = ['tool_lifecycle' => 2025050403,
-        'customfield_semester' => 2025043001, ];
+// $plugin->dependencies = ['tool_lifecycle' => 2025050403,
+        // 'customfield_semester' => 2025043001, ];

--- a/version.php
+++ b/version.php
@@ -13,7 +13,6 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
-
 /**
  * Version details.
  *
@@ -26,7 +25,7 @@ defined('MOODLE_INTERNAL') || die;
 
 $plugin->component = 'tool_lifecycle';
 $plugin->maturity = MATURITY_STABLE;
-$plugin->version = 2026012004;
+$plugin->version = 2026012005;
 $plugin->requires = 2024100700; // Requires Moodle 4.5+.
 $plugin->supported = [405, 501];
 $plugin->release   = 'v5.1-r5';


### PR DESCRIPTION
### 🔀 Purpose of this PR:
- [x] Fixes a bug
- [x] Adds new functionality (Triggers: coursefreeze, coursedelete) (Step: uclcontextfreeze)

---

### 📝 Description:

### Course Delete Fix 

**What bug does it address?**

When the `deletecourse` step deleted a course, an orphaned `tool_lifecycle_process` record was occasionally left behind pointing to the now-deleted course. On subsequent cron runs the LC would throw a fatal `dml_missing_record_exception` (course ID not found) error, breaking the entire lifecycle workflow and preventing any further processing or manual intervention via the UI.

**Why is this change necessary?**

The fatal exception blocked the workflow completely and could not be resolved without direct DB access. The never-accessed course exclusion meant courses eligible for deletion were silently skipped indefinitely.

**Expected behaviour after the change:**

- Orphaned process records (where the course no longer exists) are detected in `get_processes_by_workflow()` and moved to the `tool_lifecycle_proc_error` table rather than crashing the workflow
- `process::from_record()` uses `IGNORE_MISSING` when loading the course context, so it never throws on a deleted course
- The `errors.php` UI handles deleted course records gracefully when proceeding or rolling back, preventing a crash when actioning error records
- The `deletecourse` step self-cleans its own orphaned process record if it encounters an already-deleted course


### New subplugins 

**The archival workflow:**

- I created a configurable trigger subplugin (coursefreeze) to target courses with (default values) last acc > 1yr and creation date > 2yrs. 

- Step subplugin (uclcontextfreeze) then calls the manager/service method used by the context freeze task to successfully archive (make read-only) the triggered courses directly from Lifecycle.


The deletion workflow: 

- I created a configurable trigger subplugin (coursedelete) to target **archived** courses with (default values) Last acc > 4 years and creation date > 5 years. This currently also includes courses that have never been accessed and courses where enrolled users last access record is set to 'Never'.

The deletion workflow will use the pre existing deletecourse step in the lifecycle.

---

### 📋 Checklist
- [ ] I have `phpunit` and/or `behat` tests that cover my changes or additions.
- [x] Code passes the code checker without errors and warnings.
- [x] Code does not have `var_dump()` or `var_export` or any other debugging statements that should not appear on the productive branch.
- [x] Code only uses language strings instead of hard-coded strings.
- [x] If there are changes in the database: I updated/created the necessary upgrade steps in `db/upgrade.php` and updated the `version.php`.

---

### 📋 Files changed
- `classes/local/entity/process.php` — use `IGNORE_MISSING` in `context_course::instance()`
- `classes/local/manager/process_manager.php` — orphan detection in `get_processes_by_workflow()`
- `errors.php` — safe `get_course()` calls with try/catch for deleted courses
- `db/upgrade.php` — cleanup step for orphaned process records (version `2026012005`)
- `version.php` — bumped to `2026012005`
- `steps/deletecourse/lib.php` — self-cleaning guard for already-deleted courses

### Files added 
- `trigger/coursedelete/lib.php` — a configurable trigger to target archived courses that have Last access > x and creation date > x
- `trigger/coursefreeze/lib.php`  — a configurable trigger to target courses that have Last access > x and creation date > x
- `step/coursefreeze/lib.php`  — calls a uclcontextfreeze manager to archive courses

### Notes for reviewers
- This is a draft PR for early feedback and review
- Implementation follows existing lifecycle step/trigger structure
- Minor changes to existing functionality (error handling and course delete changes)

### Testing
- Code structure mirrors existing steps/triggers
- Ready for functional testing within main Extend environment

---

### 🔍 Related Issues
- Related to #[294]
- Related to #[240]
---

### 🧾 Additional Information

The root of the deletion error was that `delete_course()` removes the course record but does not guarantee atomic cleanup of `tool_lifecycle_process` entries, particularly if a previous cron run was interrupted. The fix applies defence in depth across three layers (entity, manager, step) so the system self-heals regardless of which code path encounters the orphaned record first.