### PR TITLE
Support multilang course titles in the backup table.

### DIFF
--- a/classes/local/table/course_backups_table.php
+++ b/classes/local/table/course_backups_table.php
@@ -165,12 +165,12 @@ class course_backups_table extends \table_sql {
      */
     public function col_coursename($row) {
         try {
-            $out = \html_writer::link(course_get_url($row->courseid), $row->coursefullname);
+            $out = \html_writer::link(course_get_url($row->courseid), format_string($row->coursefullname));
         } catch (\dml_missing_record_exception $e) {
-            $out = $row->coursefullname;
+            $out = format_string($row->coursefullname);
         }
         if ($row->coursefullname != $row->courseshortname) {
-            $out .= \html_writer::div($row->courseshortname, 'text-info');
+            $out .= \html_writer::div(format_string($row->courseshortname), 'text-info');
         }
         return $out;
     }


### PR DESCRIPTION
> **Note:** Please fill out all relevant sections and remove irrelevant ones.
### 🔀 Purpose of this PR:

- [X] Improves or enhances existing features

---

### 📝 Description:

The table that lists the course backups can deal multilang course names

---

### 📋 Checklist

Please confirm the following (check all that apply):

- [ ] I have `phpunit` and/or `behat` tests that cover my changes or additions.
- [X] Code passes the code checker without errors and warnings.
- [X] Code passes the moodle-ci/cd pipeline on all supported Moodle versions or the ones the plugin supports.
- [X] Code does not have `var_dump()` or `var_export` or any other debugging statements (or commented out code) that
  should not appear on the productive branch.
- [ ] Code only uses language strings instead of hard-coded strings.
- [ ] If there are changes in the database: I updated/created the necessary upgrade steps in `db/upgrade.php` and
  updated the `version.php`.
- [ ] If there are changes in javascript: I build new `.min` files with the `grunt amd` command.
- [ ] If it is a Moodle update PR: I read the release notes, updated the `version.php` and the `CHANGES.md`.
  I ran all tests thoroughly checking for errors. I checked if bootstrap had any changes/deprecations that require
  changes in the plugins UI.

---

### 🔍 Related Issues

- Related to #299

---

### 🧾📸🌐 Additional Information (like screenshots, documentation, links, etc.)

Any other relevant information.

---