### PR TITLE
fix: add handling of potential null returns

### DIFF
--- a/classes/local/manager/process_manager.php
+++ b/classes/local/manager/process_manager.php
@@ -353,12 +353,12 @@ class process_manager {
             if (null === $step) {
                 self::remove_process($process);
             }
-            
+
             $steplib = lib_manager::get_step_lib($step->subpluginname);
             if (null === $steplib) {
                 self::remove_process($process);
             }
-            
+
             $steplib->abort_course($process);
         }
         self::remove_process($process);

--- a/classes/local/manager/process_manager.php
+++ b/classes/local/manager/process_manager.php
@@ -350,16 +350,12 @@ class process_manager {
     public static function abort_process($process) {
         if (($process->stepindex ?? false) && ($process->workflowid ?? false)) {
             $step = step_manager::get_step_instance_by_workflow_index($process->workflowid, $process->stepindex);
-            if (null === $step) {
-                self::remove_process($process);
+            if (null !== $step) {
+                $steplib = lib_manager::get_step_lib($step->subpluginname);
+                if (null !== $steplib) {
+                    $steplib->abort_course($process);
+                }
             }
-
-            $steplib = lib_manager::get_step_lib($step->subpluginname);
-            if (null === $steplib) {
-                self::remove_process($process);
-            }
-
-            $steplib->abort_course($process);
         }
         self::remove_process($process);
     }

--- a/classes/local/manager/process_manager.php
+++ b/classes/local/manager/process_manager.php
@@ -350,7 +350,15 @@ class process_manager {
     public static function abort_process($process) {
         if (($process->stepindex ?? false) && ($process->workflowid ?? false)) {
             $step = step_manager::get_step_instance_by_workflow_index($process->workflowid, $process->stepindex);
+            if (null === $step) {
+                self::remove_process($process);
+            }
+            
             $steplib = lib_manager::get_step_lib($step->subpluginname);
+            if (null === $steplib) {
+                self::remove_process($process);
+            }
+            
             $steplib->abort_course($process);
         }
         self::remove_process($process);


### PR DESCRIPTION
See #294

The following functions might return null:
tool_lifecycle\local\manager\step_manager::get_step_instance_by_workflow_index() tool_lifecycle\local\manager\lib_manager::get_step_lib()
