### PR TITLE
Change automated backup mode, resolves #304

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+5.2.0 (2026-06-01)
+------------------
+* Moodle 5.2 compatible version
+
 5.1.5 (v5.1-r6, 2026-05-20)
 ---------------------------
 * [FEATURE] Introduce new step opencast

--- a/classes/local/manager/backup_manager.php
+++ b/classes/local/manager/backup_manager.php
@@ -73,7 +73,7 @@ class backup_manager {
         }
         // Perform Backup.
         $bc = new \backup_controller(\backup::TYPE_1COURSE, $courseid, \backup::FORMAT_MOODLE,
-            \backup::INTERACTIVE_NO, \backup::MODE_GENERAL, get_admin()->id);
+            \backup::INTERACTIVE_NO, \backup::MODE_AUTOMATED, get_admin()->id);
         $bc->execute_plan(); // Execute backup.
         $results = $bc->get_results(); // Get the file information needed.
         /* @var $file \stored_file instance of the backup file*/

--- a/step/createbackup/lang/de/lifecyclestep_createbackup.php
+++ b/step/createbackup/lang/de/lifecyclestep_createbackup.php
@@ -22,6 +22,8 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+$string['backupsettings'] = 'Backup Einstellungen';
+$string['backupsettingsstatictext'] = 'Die Konfiguration der erstellten Backups wird durch die Einstellungen für automatisierte Backups gesteuert: {$a}';
 $string['coursebackups'] = 'Kurs-Sicherungen';
 $string['deleteallbuttonlabel'] = 'Alle löschen';
 $string['deleteselectedbuttonlabel'] = 'Selektierte löschen';
@@ -30,4 +32,3 @@ $string['nobackups'] = 'Keine Backups gefunden.';
 $string['plugindescription'] = 'Stößt ein Backup der getriggerten Kurse an.';
 $string['pluginname'] = 'Kurssicherungs-Schritt';
 $string['privacy:metadata'] = 'Dieses Subplugin speichert keine persönlichen Daten.';
-

--- a/step/createbackup/lang/de/lifecyclestep_createbackup.php
+++ b/step/createbackup/lang/de/lifecyclestep_createbackup.php
@@ -23,7 +23,7 @@
  */
 
 $string['backupsettings'] = 'Backup Einstellungen';
-$string['backupsettingsstatictext'] = 'Die Konfiguration der erstellten Backups wird durch die Einstellungen für automatisierte Backups gesteuert: {$a}';
+$string['backupsettingsstatictext'] = 'Die Konfiguration der erstellten Backups wird durch die Einstellungen für automatisierte Backups gesteuert: <a href="{$a->url}">{$a->label}</a>';
 $string['coursebackups'] = 'Kurs-Sicherungen';
 $string['deleteallbuttonlabel'] = 'Alle löschen';
 $string['deleteselectedbuttonlabel'] = 'Selektierte löschen';

--- a/step/createbackup/lang/en/lifecyclestep_createbackup.php
+++ b/step/createbackup/lang/en/lifecyclestep_createbackup.php
@@ -22,6 +22,8 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+$string['backupsettings'] = 'Backup Settings';
+$string['backupsettingsstatictext'] = 'The configuration of the created backups is controlled by the automated backup settings: {$a}';
 $string['coursebackups'] = 'Course Backups';
 $string['deleteallbuttonlabel'] = 'Delete all';
 $string['deleteselectedbuttonlabel'] = 'Delete selected';
@@ -30,4 +32,3 @@ $string['nobackups'] = 'No backups found.';
 $string['plugindescription'] = 'Initiates a backup of the triggered courses.';
 $string['pluginname'] = 'Create Backup Step';
 $string['privacy:metadata'] = 'This subplugin does not store any personal data.';
-

--- a/step/createbackup/lang/en/lifecyclestep_createbackup.php
+++ b/step/createbackup/lang/en/lifecyclestep_createbackup.php
@@ -23,7 +23,7 @@
  */
 
 $string['backupsettings'] = 'Backup Settings';
-$string['backupsettingsstatictext'] = 'The configuration of the created backups is controlled by the automated backup settings: {$a}';
+$string['backupsettingsstatictext'] = 'The configuration of the created backups is controlled by the automated backup settings: <a href="{$a->url}">{$a->label}</a>';
 $string['coursebackups'] = 'Course Backups';
 $string['deleteallbuttonlabel'] = 'Delete all';
 $string['deleteselectedbuttonlabel'] = 'Delete selected';

--- a/step/createbackup/lib.php
+++ b/step/createbackup/lib.php
@@ -136,9 +136,10 @@ class createbackup extends libbase {
         $elementname = 'maximumbackupspercron';
         $mform->addElement('text', $elementname,
             get_string('maximumbackupspercron', 'lifecyclestep_createbackup'),
-            ['size' => 3]);
+            ['size' => 3]
+        );
         $mform->setType($elementname, PARAM_INT);
-	$mform->setDefault($elementname, 10);
+        $mform->setDefault($elementname, 10);
     }
 
     /**

--- a/step/createbackup/lib.php
+++ b/step/createbackup/lib.php
@@ -117,6 +117,12 @@ class createbackup extends libbase {
      * @throws \coding_exception
      */
     public function extend_add_instance_form_definition($mform) {
+        $elementname = 'backupsettings';
+        $backupsettingsurl = new \moodle_url('/admin/settings.php', ['section' => 'automated']);
+        $backupsettingslink = html_writer::link($backupsettingsurl, get_string('automatedsetup', 'backup'));
+        $mform->addElement('static', $elementname, get_string('backupsettings', 'lifecyclestep_createbackup'),
+            get_string('backupsettingsstatictext', 'lifecyclestep_createbackup', $backupsettingslink)
+        );
         $elementname = 'status';
         $options = [
             self::STEPACTIVE => get_string('active', 'tool_lifecycle'),
@@ -132,7 +138,7 @@ class createbackup extends libbase {
             get_string('maximumbackupspercron', 'lifecyclestep_createbackup'),
             ['size' => 3]);
         $mform->setType($elementname, PARAM_INT);
-        $mform->setDefault($elementname, 10);
+	$mform->setDefault($elementname, 10);
     }
 
     /**

--- a/step/createbackup/lib.php
+++ b/step/createbackup/lib.php
@@ -118,10 +118,11 @@ class createbackup extends libbase {
      */
     public function extend_add_instance_form_definition($mform) {
         $elementname = 'backupsettings';
-        $backupsettingsurl = new \moodle_url('/admin/settings.php', ['section' => 'automated']);
-        $backupsettingslink = html_writer::link($backupsettingsurl, get_string('automatedsetup', 'backup'));
+        $backupsettings = new stdClass;
+        $backupsettings->url = (new \moodle_url('/admin/settings.php', ['section' => 'automated']))->out();
+        $backupsettings->label = get_string('automatedsetup', 'backup');
         $mform->addElement('static', $elementname, get_string('backupsettings', 'lifecyclestep_createbackup'),
-            get_string('backupsettingsstatictext', 'lifecyclestep_createbackup', $backupsettingslink)
+            get_string('backupsettingsstatictext', 'lifecyclestep_createbackup', $backupsettings)
         );
         $elementname = 'status';
         $options = [

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@ defined('MOODLE_INTERNAL') || die;
 
 $plugin->component = 'tool_lifecycle';
 $plugin->maturity = MATURITY_STABLE;
-$plugin->version = 2026012005;
+$plugin->version = 2026060100;
 $plugin->requires = 2024100700; // Requires Moodle 4.5+.
-$plugin->supported = [405, 501];
-$plugin->release   = 'v5.1-r6';
+$plugin->supported = [405, 502];
+$plugin->release   = 'v5.2-r1';


### PR DESCRIPTION
### 🔀 Purpose of this PR:
-  Improves or enhances existing features: Use settings for automated backups instead of general backup base settings
- Miscellaneous: Add description which settings are used for the backups and link to the settings page

### 📋 Checklist

Please confirm the following (check all that apply):

- [ ] I have `phpunit` and/or `behat` tests that cover my changes or additions.
 - Dont think this change needs any - can provide them if needed 
- [X] Code passes the code checker without errors and warnings.
- [X] Code passes the moodle-ci/cd pipeline on all supported Moodle versions or the ones the plugin supports.
 - One Random Timeout in last run
- [X] Code does not have `var_dump()` or `var_export` or any other debugging statements (or commented out code) that
  should not appear on the productive branch.
- [X] Code only uses language strings instead of hard-coded strings.
---

### 🔍 Related Issues

- Related to #304 