### PR TITLE
Add privacy provider for step_pushbackuptask subplugin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+5.2.0 (2026-06-01)
+------------------
+* Moodle 5.2 compatible version
+
 5.1.5 (v5.1-r6, 2026-05-20)
 ---------------------------
 * [FEATURE] Introduce new step opencast

--- a/step/pushbackuptask/classes/privacy/provider.php
+++ b/step/pushbackuptask/classes/privacy/provider.php
@@ -1,0 +1,38 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace lifecyclestep_pushbackuptask\privacy;
+
+use core_privacy\local\metadata\null_provider;
+
+/**
+ * Privacy subsystem implementation for lifecyclestep_pushbackuptask.
+ *
+ * @package     lifecyclestep_pushbackuptask
+ * @copyright   2024 Johannes Burk (HTW Berlin)
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class provider implements null_provider {
+
+    /**
+     * Get the language string identifier explaining why this plugin stores no data.
+     *
+     * @return string the reason
+     */
+    public static function get_reason(): string {
+        return 'privacy:metadata';
+    }
+}

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@ defined('MOODLE_INTERNAL') || die;
 
 $plugin->component = 'tool_lifecycle';
 $plugin->maturity = MATURITY_STABLE;
-$plugin->version = 2026012005;
+$plugin->version = 2026060100;
 $plugin->requires = 2024100700; // Requires Moodle 4.5+.
-$plugin->supported = [405, 501];
-$plugin->release   = 'v5.1-r6';
+$plugin->supported = [405, 502];
+$plugin->release   = 'v5.2-r1';


### PR DESCRIPTION
> **Note:** Please fill out all relevant sections and remove irrelevant ones.
### 🔀 Purpose of this PR:

- [x] Testing: add missing or improve existing tests


---

### 📝 Description:

Add privacy provider

---

### 📋 Checklist

Please confirm the following (check all that apply):

- [x] I have `phpunit` and/or `behat` tests that cover my changes or additions.
- [x] Code passes the code checker without errors and warnings.
- [x] Code passes the moodle-ci/cd pipeline on all supported Moodle versions or the ones the plugin supports.
- [x] Code does not have `var_dump()` or `var_export` or any other debugging statements (or commented out code) that
  should not appear on the productive branch.
- [x] Code only uses language strings instead of hard-coded strings.
- [ ] If there are changes in the database: I updated/created the necessary upgrade steps in `db/upgrade.php` and
  updated the `version.php`.
- [ ] If there are changes in javascript: I build new `.min` files with the `grunt amd` command.
- [ ] If it is a Moodle update PR: I read the release notes, updated the `version.php` and the `CHANGES.md`.
  I ran all tests thoroughly checking for errors. I checked if bootstrap had any changes/deprecations that require
  changes in the plugins UI.

---

### 🔍 Related Issues

- Related to #306

---

### 🧾📸🌐 Additional Information (like screenshots, documentation, links, etc.)

Running failing unit test after fix

```
> vendor/bin/phpunit --filter test_all_providers_compliant privacy/tests/privacy/provider_test.php
Moodle 4.5.11+ (Build: 20260501), 11cb1f29138b7bf3a451cad5cc1edc4b1ef85693
Php: 8.3.27, pgsql: 17.10 (Debian 17.10-1.pgdg13+1), OS: Linux 6.17.0-35-generic x86_64
PHPUnit 9.6.34 by Sebastian Bergmann and contributors.

...............................................................  63 / 632 (  9%)
............................................................... 126 / 632 ( 19%)
............................................................... 189 / 632 ( 29%)
............................................................... 252 / 632 ( 39%)
............................................................... 315 / 632 ( 49%)
............................................................... 378 / 632 ( 59%)
............................................................... 441 / 632 ( 69%)
............................................................... 504 / 632 ( 79%)
............................................................... 567 / 632 ( 89%)
............................................................... 630 / 632 ( 99%)
..                                                              632 / 632 (100%)

Time: 01:17.906, Memory: 98.50 MB

OK (632 tests, 632 assertions)
```

---