### PR TITLE
Fixes Error: Workflows with triggers, which have more than 65.535 parameters (or course IDs) with PostgreSQL throw an error (in all versions)

### DIFF
--- a/classes/local/intersectedRecordset.php
+++ b/classes/local/intersectedRecordset.php
@@ -29,6 +29,7 @@ defined('MOODLE_INTERNAL') || die();
 class intersectedRecordset implements \Iterator, \Countable {
     private $records = [];
     private $position = 0;
+    private $wasFilled = false;
 
     /**
      * Constructor: Inits class & intersects passed recordsets.
@@ -51,32 +52,36 @@ class intersectedRecordset implements \Iterator, \Countable {
      * @param string $key
      */
     public function add($recordset, string $key = 'id'): void {
+        // Add new records to array with key
         $newRecords = [];
-        foreach($recordset as $record) { $newRecords[] = $record; }
+        foreach($recordset as $record) {
+            if(isset($record->$key)) { $newRecords[$record->$key] = $record; }
+        }
         //$recordset->close();
 
-        $newRecordsByKey = [];
-        foreach($newRecords as $record) {
-            if(isset($record->$key)) { $newRecordsByKey[$record->$key] = $record; }
-        }
-
-        if(empty($this->records)) {
-            $this->records = array_values($newRecordsByKey);
+        // Store new records without key, if no records were stored & return
+        if(empty($this->records) && !$this->wasFilled) {
+            $this->records = array_values($newRecords);
+            $this->wasFilled = true;
 
             return;
         }
 
-        $existingRecordsByKey = [];
+        // Add existing records to array with key
+        $existingRecords = [];
         foreach($this->records as $record) {
-            if(isset($record->$key)) { $existingRecordsByKey[$record->$key] = $record; }
+            if(isset($record->$key)) { $existingRecords[$record->$key] = $record; }
         }
 
-        $intersectionKeys = array_intersect_key($existingRecordsByKey, $newRecordsByKey);
-
+        // Intersect existing & new records by keys
+        $intersectionKeys = array_intersect_key($existingRecords, $newRecords);
+        // Clear existing records
         $this->records = [];
+        // Store intersected records by keys
         foreach($intersectionKeys as $keyValue => $record) {
-            $this->records[] = $existingRecordsByKey[$keyValue];
+            $this->records[] = $existingRecords[$keyValue];
         }
+        //mtrace('Add - Intersected record sets: '.count($this->records));
     }
 
     /**

--- a/classes/local/intersectedRecordset.php
+++ b/classes/local/intersectedRecordset.php
@@ -1,0 +1,131 @@
+<?php
+
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Helper class which intersects multiple moodle record sets.
+ *
+ * @package    tool_lifecycle
+ * @copyright  2025 Michael Schink JKU
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+namespace tool_lifecycle\local;
+
+defined('MOODLE_INTERNAL') || die();
+
+class intersectedRecordset implements \Iterator, \Countable {
+    private $records = [];
+    private $position = 0;
+
+    /**
+     * Constructor: Inits class & intersects passed recordsets.
+     *
+     * @param moodle_recordset|array|null $recordsets
+     * @param string $key
+     */
+    public function __construct($recordsets = null, string $key = 'id') {
+        if($recordsets !== null) {
+            if(is_array($recordsets)) {
+                foreach($recordsets as $recordset) { $this->add($recordset, $key); }
+            } else { $this->add($recordsets, $key); }
+        }
+    }
+
+    /**
+     * Adds recordset & saves intersection of all recordsets.
+     *
+     * @param moodle_recordset $recordset
+     * @param string $key
+     */
+    public function add($recordset, string $key = 'id'): void {
+        $newRecords = [];
+        foreach($recordset as $record) { $newRecords[] = $record; }
+        //$recordset->close();
+
+        $newRecordsByKey = [];
+        foreach($newRecords as $record) {
+            if(isset($record->$key)) { $newRecordsByKey[$record->$key] = $record; }
+        }
+
+        if(empty($this->records)) {
+            $this->records = array_values($newRecordsByKey);
+
+            return;
+        }
+
+        $existingRecordsByKey = [];
+        foreach($this->records as $record) {
+            if(isset($record->$key)) { $existingRecordsByKey[$record->$key] = $record; }
+        }
+
+        $intersectionKeys = array_intersect_key($existingRecordsByKey, $newRecordsByKey);
+
+        $this->records = [];
+        foreach($intersectionKeys as $keyValue => $record) {
+            $this->records[] = $existingRecordsByKey[$keyValue];
+        }
+    }
+
+    /**
+     * Returns current recordset.
+     *
+     * @return mixed
+     */
+    public function current(): mixed {
+        return $this->records[$this->position];
+    }
+
+    /**
+     * Returns current key (index).
+     *
+     * @return int
+     */
+    public function key(): int {
+        return $this->position;
+    }
+
+    /**
+     * Moves internal pointer to next recordset.
+     */
+    public function next(): void {
+        $this->position++;
+    }
+
+    /**
+     * Returns internal pointer to start.
+     */
+    public function rewind(): void {
+        $this->position = 0;
+    }
+
+    /**
+     * Checks if current pointer points to a valid recordset.
+     *
+     * @return bool
+     */
+    public function valid(): bool {
+        return isset($this->records[$this->position]);
+    }
+
+    /**
+     * Returns the amount of all recordsets.
+     *
+     * @return int
+     */
+    public function count(): int {
+        return count($this->records);
+    }
+}

--- a/classes/local/intersectedRecordset.php
+++ b/classes/local/intersectedRecordset.php
@@ -40,7 +40,27 @@ class intersectedRecordset implements \Iterator, \Countable {
     public function __construct($recordsets = null, string $key = 'id') {
         if($recordsets !== null) {
             if(is_array($recordsets)) {
-                foreach($recordsets as $recordset) { $this->add($recordset, $key); }
+                // For multiple recordsets
+                foreach($recordsets as $recordset) {
+                    // If recordset is a chunked recordset
+                    if(is_array($recordset)) {
+                        mtrace('Chunked recordset');
+                        // Create new array for chunked recordset
+                        $chunkedRecords = [];
+                        // For each chunked recordset
+                        foreach($recordset as $chunk_recordset) {
+                            // For each record in chunked recordset
+                            foreach($chunk_recordset as $record) {
+                                if(isset($record->$key)) { $chunkedRecords[$record->$key] = $record; }
+                            }
+                        }
+                        // Add all records of chunked recordsets
+                        $this->add($chunkedRecords, $key);
+                    } else {
+                        mtrace('Normal recordset');
+                        $this->add($recordset, $key);
+                    }
+                }
             } else { $this->add($recordsets, $key); }
         }
     }
@@ -57,6 +77,7 @@ class intersectedRecordset implements \Iterator, \Countable {
         foreach($recordset as $record) {
             if(isset($record->$key)) { $newRecords[$record->$key] = $record; }
         }
+        mtrace('     Found '.count($newRecords).' records in recordset');
         //$recordset->close();
 
         // Store new records without key, if no records were stored & return

--- a/classes/processor.php
+++ b/classes/processor.php
@@ -195,26 +195,31 @@ class processor {
     public function get_course_recordset($triggers, $exclude, $forcounting = false) {
         global $DB;
 
-        $where = 'true';
+        // Mike
+        $where = [];
         $whereparams = [];
+        //$chunks = array_chunk($whereparams, 65535, true);
+        $recordsets = [];
         foreach ($triggers as $trigger) {
             $lib = lib_manager::get_automatic_trigger_lib($trigger->subpluginname);
             [$sql, $params] = $lib->get_course_recordset_where($trigger->id);
             if (!empty($sql)) {
-                $where .= ' AND ' . $sql;
-                $whereparams = array_merge($whereparams, $params);
+                $where[] = 'true AND ' . $sql;
+                $whereparams[] = $params;
             }
         }
 
         if (!empty($exclude)) {
             [$insql, $inparams] = $DB->get_in_or_equal($exclude, SQL_PARAMS_NAMED);
-            $where .= " AND NOT {course}.id {$insql}";
-            $whereparams = array_merge($whereparams, $inparams);
+            $where[] = "true AND NOT {course}.id {$insql}";
+            $whereparams[] = $inparams;
         }
 
         if ($forcounting) {
-            // Get course hasotherprocess and delay with the sql.
-            $sql = "SELECT {course}.id,
+            foreach ($where as $key => $where_tmp) {
+                $whereparams_tmp = $whereparams[$key];
+                // Get course hasotherprocess and delay with the sql.
+                $sql = "SELECT {course}.id,
                     COALESCE(p.courseid, pe.courseid, 0) as hasprocess,
                     CASE
                         WHEN COALESCE(p.workflowid, 0) > COALESCE(pe.workflowid, 0) THEN p.workflowid
@@ -232,17 +237,32 @@ class processor {
                     LEFT JOIN {tool_lifecycle_proc_error} pe ON {course}.id = pe.courseid
                     LEFT JOIN {tool_lifecycle_delayed} d ON {course}.id = d.courseid
                     LEFT JOIN {tool_lifecycle_delayed_workf} dw ON {course}.id = dw.courseid
-                    WHERE " . $where;
+                    WHERE " . $where_tmp;
+                $recordsets[] = $DB->get_recordset_sql($sql, $whereparams_tmp);
+            }
+
+            //use tool_lifecycle\local\intersectedRecordset;
+            $recordsets = new \tool_lifecycle\local\intersectedRecordset($recordsets);
+            mtrace('Intersected record sets (for counting): '.count($recordsets));
         } else {
-            // Get only courses which are not part of an existing process.
-            $sql = 'SELECT {course}.id from {course} '.
-                'LEFT JOIN {tool_lifecycle_process} '.
-                'ON {course}.id = {tool_lifecycle_process}.courseid '.
-                'LEFT JOIN {tool_lifecycle_proc_error} pe ON {course}.id = pe.courseid ' .
-                'WHERE {tool_lifecycle_process}.courseid is null AND ' .
-                'pe.courseid IS NULL AND '. $where;
+            foreach ($where as $key => $where_tmp) {
+                $whereparams_tmp = $whereparams[$key];
+                // Get only courses which are not part of an existing process.
+                $sql = 'SELECT {course}.id from {course} '.
+                    'LEFT JOIN {tool_lifecycle_process} '.
+                    'ON {course}.id = {tool_lifecycle_process}.courseid '.
+                    'LEFT JOIN {tool_lifecycle_proc_error} pe ON {course}.id = pe.courseid ' .
+                    'WHERE {tool_lifecycle_process}.courseid is null AND ' .
+                    'pe.courseid IS NULL AND '. $where_tmp;
+                $recordsets[] = $DB->get_recordset_sql($sql, $whereparams_tmp);
+            }
+
+            //use tool_lifecycle\local\intersectedRecordset;
+            $recordsets = new \tool_lifecycle\local\intersectedRecordset($recordsets);
+            mtrace('Intersected record sets: '.count($recordsets));
         }
-        return $DB->get_recordset_sql($sql, $whereparams);
+
+        return $recordsets;
     }
 
     /**
@@ -435,6 +455,8 @@ class processor {
         $all->delayedcourses = $delayedcourses; // Delayed courses for workflow and globally. Excluded per default.
         $all->used = $usedcourses;
         $all->nextrun = $nextrun;
+        // Mike
+        mtrace('Courses triggered by workflow: '.count($all->triggered));
         $amounts['all'] = $all;
         return $amounts;
     }

--- a/classes/processor.php
+++ b/classes/processor.php
@@ -215,9 +215,9 @@ class processor {
         }
 
         $maxparams = 65535;
-        //$maxparams = 4;
+        //$maxparams = 1000;
         mtrace('');
-        mtrace('Start - MAX params: '.$maxparams.', where parts: '.count($where)/*.' '.print_r($where, true)*/.' & params '.count($whereparams)/*.' '.print_r($whereparams, true)*/);
+        mtrace('Start - MAX params: '.$maxparams.', trigger where parts: '.count($where)/*.' '.print_r($where, true)*/.' & params: '.count($whereparams)/*.' '.print_r($whereparams, true)*/);
         foreach($whereparams as $key => $whereparam) {
             if(count($whereparam) > $maxparams) {
                 mtrace('More than '.$maxparams.' params with key '.$key.': '.count($whereparam));
@@ -250,7 +250,8 @@ class processor {
                     $whereparam_chunk_string = implode(',', array_map(function($value) { return ':' . $value; }, array_keys($whereparam_chunk)));
                     // Re-create where part for chunk
                     $where_chunk = $before.$whereparam_chunk_string.$after;
-                    mtrace('   5.'.$counter.' Add chunk query: '.$where_chunk.' & params: '.count($whereparam_chunk)/*.print_r($whereparam_chunk, true)*/);
+                    if(count($whereparam_chunks) > 10 && $counter == 10 ) { mtrace('   ...'); }
+                    if($counter < 5 || $counter >= (count($whereparam_chunks) - 5)) { mtrace('   5.'.$counter.' Add chunk query: '.(strlen($where_chunk) > 150 ? substr($where_chunk, 0, 150) . '...' : $where_chunk).' & params: '.count($whereparam_chunk)/*.print_r($whereparam_chunk, true)*/); }
                     // Add where part & params of chunk
                     if(count($where) && count($whereparams)) {
                         $where[$key][] = $where_chunk;
@@ -259,7 +260,7 @@ class processor {
                 }
             }
         }
-        mtrace('End - MAX params: '.$maxparams.', where parts: '.count($where)/*.' '.print_r($where, true)*/.' & params '.count($whereparams)/*.' '.print_r($whereparams, true)*/);
+        mtrace('End - MAX params: '.$maxparams.', trigger where parts: '.count($where)/*.' '.print_r($where, true)*/.' & params '.count($whereparams)/*.' '.print_r($whereparams, true)*/);
         mtrace('');
         //die();
 

--- a/classes/processor.php
+++ b/classes/processor.php
@@ -243,7 +243,7 @@ class processor {
 
             //use tool_lifecycle\local\intersectedRecordset;
             $recordsets = new \tool_lifecycle\local\intersectedRecordset($recordsets);
-            mtrace('Intersected record sets (for counting): '.count($recordsets));
+            //mtrace('Intersected record sets (for counting): '.count($recordsets));
         } else {
             foreach ($where as $key => $where_tmp) {
                 $whereparams_tmp = $whereparams[$key];
@@ -259,7 +259,7 @@ class processor {
 
             //use tool_lifecycle\local\intersectedRecordset;
             $recordsets = new \tool_lifecycle\local\intersectedRecordset($recordsets);
-            mtrace('Intersected record sets: '.count($recordsets));
+            //mtrace('Intersected record sets: '.count($recordsets));
         }
 
         return $recordsets;

--- a/classes/processor.php
+++ b/classes/processor.php
@@ -198,7 +198,6 @@ class processor {
         // Mike
         $where = [];
         $whereparams = [];
-        //$chunks = array_chunk($whereparams, 65535, true);
         $recordsets = [];
         foreach ($triggers as $trigger) {
             $lib = lib_manager::get_automatic_trigger_lib($trigger->subpluginname);
@@ -214,6 +213,55 @@ class processor {
             $where[] = "true AND NOT {course}.id {$insql}";
             $whereparams[] = $inparams;
         }
+
+        $maxparams = 65535;
+        //$maxparams = 4;
+        mtrace('');
+        mtrace('Start - MAX params: '.$maxparams.', where parts: '.count($where)/*.' '.print_r($where, true)*/.' & params '.count($whereparams)/*.' '.print_r($whereparams, true)*/);
+        foreach($whereparams as $key => $whereparam) {
+            if(count($whereparam) > $maxparams) {
+                mtrace('More than '.$maxparams.' params with key '.$key.': '.count($whereparam));
+                // Get where part of params array
+                $wherepart = $where[$key];
+                // Get first & last param
+                $first = ':'.array_key_first($whereparam);
+                $last = ':'.array_key_last($whereparam);
+                mtrace('   1. Get first param '.$first.' & last param '.$last);
+                // Get where part before first param & after last param (to re-create where part)
+                $position = strpos($wherepart, $first);
+                $before = substr($wherepart, 0, $position);
+                $position = strpos($wherepart, $last);
+                $after = substr($wherepart, $position + strlen($last));
+                mtrace('   2. Re-create where part: '.$before.' <enter-params> '.$after);
+                // Remove original where part & params
+                //unset($where[$key]);
+                //unset($whereparams[$key]);
+                $where[$key] = [];
+                $whereparams[$key] = [];
+                mtrace('   3. Remove where part & params with key: '.$key);
+                // Chunk params
+                $whereparam_chunks = array_chunk($whereparam, $maxparams, true);
+                mtrace('   4. Chunk params: '.count($whereparam_chunks)/*.print_r($whereparam_chunks, true))*/.' ('.count($whereparam).'/'.$maxparams.')');
+                // For each chunk of params
+                $counter = 0;
+                foreach($whereparam_chunks as $whereparam_chunk) {
+                    $counter++;
+                    // Create param string of chunk params
+                    $whereparam_chunk_string = implode(',', array_map(function($value) { return ':' . $value; }, array_keys($whereparam_chunk)));
+                    // Re-create where part for chunk
+                    $where_chunk = $before.$whereparam_chunk_string.$after;
+                    mtrace('   5.'.$counter.' Add chunk query: '.$where_chunk.' & params: '.count($whereparam_chunk)/*.print_r($whereparam_chunk, true)*/);
+                    // Add where part & params of chunk
+                    if(count($where) && count($whereparams)) {
+                        $where[$key][] = $where_chunk;
+                        $whereparams[$key][] = $whereparam_chunk;
+                    } else { mtrace('ERROR: Amount of where parts & params are not the same!'); }
+                }
+            }
+        }
+        mtrace('End - MAX params: '.$maxparams.', where parts: '.count($where)/*.' '.print_r($where, true)*/.' & params '.count($whereparams)/*.' '.print_r($whereparams, true)*/);
+        mtrace('');
+        //die();
 
         if ($forcounting) {
             foreach ($where as $key => $where_tmp) {
@@ -237,8 +285,21 @@ class processor {
                     LEFT JOIN {tool_lifecycle_proc_error} pe ON {course}.id = pe.courseid
                     LEFT JOIN {tool_lifecycle_delayed} d ON {course}.id = d.courseid
                     LEFT JOIN {tool_lifecycle_delayed_workf} dw ON {course}.id = dw.courseid
-                    WHERE " . $where_tmp;
-                $recordsets[] = $DB->get_recordset_sql($sql, $whereparams_tmp);
+                    WHERE ";
+
+                if(is_array($where_tmp)) {
+                    //mtrace('Chunked recordset: '.count($where_tmp)/*.' '.print_r($where_tmp, true)*/.', params: '.count($whereparams_tmp)/*.' '.print_r($whereparams_tmp, true)*/);
+                    $tmp = [];
+                    foreach($where_tmp as $chunk_key => $chunk_where_tmp) {
+                        $sql_tmp = $sql.$chunk_where_tmp;
+                        $tmp[] = $DB->get_recordset_sql($sql_tmp, $whereparams_tmp[$chunk_key]);
+                    }
+                    $recordsets[] = $tmp;
+                } else {
+                    //mtrace('Nomrmal recordset: '.$where_tmp.', params: '.count($whereparams_tmp)/*.' '.print_r($whereparams_tmp, true)*/);
+                    $sql_tmp = $sql.$where_tmp;
+                    $recordsets[] = $DB->get_recordset_sql($sql_tmp, $whereparams_tmp);
+                }
             }
 
             //use tool_lifecycle\local\intersectedRecordset;
@@ -249,18 +310,36 @@ class processor {
                 $whereparams_tmp = $whereparams[$key];
                 // Get only courses which are not part of an existing process.
                 $sql = 'SELECT {course}.id from {course} '.
-                    'LEFT JOIN {tool_lifecycle_process} '.
-                    'ON {course}.id = {tool_lifecycle_process}.courseid '.
-                    'LEFT JOIN {tool_lifecycle_proc_error} pe ON {course}.id = pe.courseid ' .
-                    'WHERE {tool_lifecycle_process}.courseid is null AND ' .
-                    'pe.courseid IS NULL AND '. $where_tmp;
-                $recordsets[] = $DB->get_recordset_sql($sql, $whereparams_tmp);
+                        'LEFT JOIN {tool_lifecycle_process} '.
+                        'ON {course}.id = {tool_lifecycle_process}.courseid '.
+                        'LEFT JOIN {tool_lifecycle_proc_error} pe ON {course}.id = pe.courseid ' .
+                        'WHERE {tool_lifecycle_process}.courseid is null AND ' .
+                        'pe.courseid IS NULL AND ';
+
+                if(is_array($where_tmp)) {
+                    //mtrace('Chunked recordset: '.count($where_tmp)/*.' '.print_r($where_tmp, true)*/.', params: '.count($whereparams_tmp)/*.' '.print_r($whereparams_tmp, true)*/);
+                    $tmp = [];
+                    foreach($where_tmp as $chunk_key => $chunk_where_tmp) {
+                        $sql_tmp = $sql.$chunk_where_tmp;
+                        $tmp[] = $DB->get_recordset_sql($sql_tmp, $whereparams_tmp[$chunk_key]);
+                    }
+                    $recordsets[] = $tmp;
+                } else {
+                    //mtrace('Nomrmal recordset: '.$where_tmp.', params: '.count($whereparams_tmp)/*.' '.print_r($whereparams_tmp, true)*/);
+                    $sql_tmp = $sql.$where_tmp;
+                    $recordsets[] = $DB->get_recordset_sql($sql_tmp, $whereparams_tmp);
+                }
             }
 
             //use tool_lifecycle\local\intersectedRecordset;
             $recordsets = new \tool_lifecycle\local\intersectedRecordset($recordsets);
             //mtrace('Intersected record sets: '.count($recordsets));
         }
+
+        mtrace('');
+        mtrace('FINAL recordsets: '.$recordsets->count()/*.' '.print_r($recordsets, true)*/);
+        mtrace('');
+        //die();
 
         return $recordsets;
     }


### PR DESCRIPTION
v2
* Extends last partial solution
* Split db query for each trigger (= calculating trigger to courses) into "chunked sub queries" (for each trigger), based on the amount of params
* Set max params for each trigger query to 65.535 (for PostgreSQL)
* Should be final solution

v1 (Issue: #243)
* Split single db query for calculating "triggers to courses" into a single db query for each trigger to prevent error, if more than 65.535 courses are calculated
* Not the best solution, because it only works if no trigger has more than 65.535 courses (with PostgreSQL)

### 🔀 Purpose of this PR:

- [X] Fixes a bug
- [ ] Updates for a new Moodle version
- [ ] Adds a new feature of functionality
- [X] Improves or enhances existing features
- [X] Refactoring: restructures code for better performance or maintainability
- [ ] Testing: add missing or improve existing tests
- [ ] Miscellaneous: code cleaning (without functional changes), documentation, configuration, ...

---

### 📝 Description:

The core issue is that all triggers are "calculated" in one database query to produce a single moodle_recordset as the result. **If the combined triggers of a workflow contain more than 65.535 parameters (or course IDs) using PostgreSQL an error is thrown.** The following screenshot shows the error when a workflow (with more than 65.535 parameters) is shown with version **v4.4-r1**.

<img width="1919" height="965" alt="65.535 courses error" src="https://github.com/user-attachments/assets/3bef2bff-3308-479c-9525-c46a7de340bd" />

The next screenshots show the same error with version **v5.2-r1.**

<img width="1794" height="1166" alt="mdl515-65535-parameters-error-0" src="https://github.com/user-attachments/assets/b2767ef9-a77b-4a0e-a003-494e8a60d503" />

<img width="2048" height="1167" alt="mdl515-65535-parameters-error-1" src="https://github.com/user-attachments/assets/1e36ad92-0e1e-4313-b314-19f5326d957d" />

<img width="2048" height="1169" alt="mdl515-65535-parameters-error-2" src="https://github.com/user-attachments/assets/fbfb6405-5830-463e-ad0f-db40176f0045" />

A moodle_recordset can only be used or iterated through once. After that the results are no longer available and there is no way to merge multiple moodle_recordsets.

**v1:** (Issue: #243)
To address this I created a "helper class" that behaves like a moodle_recordset and allows moodle_recordsets to be added to it. If a moodle_recordset is added an intersection is created between the existing and the new moodle_recordset and this intersection is stored in the class. The exception is the first added moodle_recordset, which is entirely stored as the starting point.

This makes it possible to execute a separate database query for each trigger while still obtaining a single moodle_recordset as the final result. However, the issue reoccurs if a single trigger exceeds the 65.535 parameters (or course IDs) limit (with PostgreSQL). This is the reason why this bugfix is an interim solution only and i didn't make a pull request so far. A complete solution would involve splitting all parameters from all triggers into chunks smaller or equal to 65.535 and then performing a database query for each of these chunks.

**v2:**
This extension of v1 addresses the issue of the bugfix where the original error reoccurs if a single trigger exceeds 65.535 parameters or course IDs. Now, the variable `$maxparams` defines the upper limit for the parameters and can be adapted for all databases. If this limit is exceeded for a trigger, the parameters are split into smaller chunks (, based on the upper limit). Additionally, the (partial) query of the affected trigger is reconstructed and filled with the corresponding "chunk parameters." These new "chunk pairs" then replace the original (partial) query and parameters of the trigger in the form of sub-arrays. Subsequently, a separate query is executed for each element of the sub-array and the results are stored in the same structure.

Similarly, the constructor of the "helper class" (, which is required to simulate a final moodle_recordset) has been extended to recognize these sub-arrays with "chunk results." If this is the case, all results or moodle_recordsets of a "chunk result" are first aggregated into a single result, which is then added to build (and store) the intersection with the existing result of the triggers. **This should be the final solution for this problem.** The current solution has only been implemented **for tool_lifecycle v4.5 (v4.5-r4 2025050403), v5.0 (v5.0-r3 2025102302) & v5.2 (v5.2-r1 2026060102)**.

**In short:** If the parameter limit per trigger is exceeded, these queries are split into smaller queries and their results are reassembled before determining the intersection with the remaining triggers.

**This error occurs in older versions as well as in the new 5.2 version.** I have adapted the **method get_course_recordset()** in the file **classes/processor.php** and added a **new class called intersectedRecordset** in the **classes/local/** dir.

---

### 📋 Checklist

- [ ] I have `phpunit` and/or `behat` tests that cover my changes or additions.
- [ ] Code passes the code checker without errors and warnings.
- [ ] Code passes the moodle-ci/cd pipeline on all supported Moodle versions or the ones the plugin supports.
- [x] Code does not have `var_dump()` or `var_export` or any other debugging statements (or commented out code) that
  should not appear on the productive branch.
- [x] Code only uses language strings instead of hard-coded strings.
- [ ] If there are changes in the database: I updated/created the necessary upgrade steps in `db/upgrade.php` and
  updated the `version.php`.
- [ ] If there are changes in javascript: I build new `.min` files with the `grunt amd` command.
- [ ] If it is a Moodle update PR: I read the release notes, updated the `version.php` and the `CHANGES.md`.
  I ran all tests thoroughly checking for errors. I checked if bootstrap had any changes/deprecations that require
  changes in the plugins UI.

---

### 🔍 Related Issues

- Related to #243

---