### PR TITLE
Add missing field "forum_discussion"

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -119,6 +119,7 @@
         <FIELD NAME="triggeredperday" TYPE="int" LENGTH="5" NOTNULL="false" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="andor" TYPE="int" LENGTH="1" NOTNULL="false" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="description" TYPE="char" LENGTH="500" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="forum_discussion" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -664,21 +664,6 @@ function xmldb_tool_lifecycle_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2026012001, 'tool', 'lifecycle');
     }
 
-    if ($oldversion < 2026012002) {
-
-        // Define field forum_discussion to be added to tool_lifecycle_workflow.
-        $table = new xmldb_table('tool_lifecycle_workflow');
-        $field = new xmldb_field('forum_discussion', XMLDB_TYPE_INTEGER, '10', null, null, null, null, 'description');
-
-        // Conditionally launch add field forum_discussion.
-        if (!$dbman->field_exists($table, $field)) {
-            $dbman->add_field($table, $field);
-        }
-
-        // Lifecycle savepoint reached.
-        upgrade_plugin_savepoint(true, 2026012002, 'tool', 'lifecycle');
-    }
-
     if ($oldversion < 2026012003) {
 
         $sql = "SELECT s.instanceid
@@ -741,6 +726,20 @@ function xmldb_tool_lifecycle_upgrade($oldversion) {
 
         // Lifecycle savepoint reached.
         upgrade_plugin_savepoint(true, 2026060101, 'tool', 'lifecycle');
+    }
+
+    if ($oldversion < 2026082501) {
+        // Define field forum_discussion to be added to tool_lifecycle_workflow.
+        $table = new xmldb_table('tool_lifecycle_workflow');
+        $field = new xmldb_field('forum_discussion', XMLDB_TYPE_INTEGER, '10', null, null, null, null, 'description');
+
+        // Conditionally launch add field forum_discussion.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Lifecycle savepoint reached.
+        upgrade_plugin_savepoint(true, 2026082501, 'tool', 'lifecycle');
     }
 
     return true;

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@ defined('MOODLE_INTERNAL') || die;
 
 $plugin->component = 'tool_lifecycle';
 $plugin->maturity = MATURITY_STABLE;
-$plugin->version = 2026060101;
+$plugin->version = 2026082501;
 $plugin->requires = 2024100700; // Requires Moodle 5.0+.
 $plugin->supported = [500, 502];
 $plugin->release   = 'v5.2-r2';


### PR DESCRIPTION
### 🔀 Purpose of this PR:

- [x ] Fixes a bug
- [ ] Updates for a new Moodle version
- [ ] Adds a new feature of functionality
- [ ] Improves or enhances existing features
- [ ] Refactoring: restructures code for better performance or maintainability
- [ ] Testing: add missing or improve existing tests
- [ ] Miscellaneous: code cleaning (without functional changes), documentation, configuration, ...

---

### 📝 Description:

The field "forum_discussion" is not created during installation. It is only created when updating from a version lower than 2026012002.

This PR adds the field "forum_discussion" to db/install.xml. Additionally, it creates a new plugin version with a new update savepoint which creates the field for all fresh installations after 2026012002.

---

### 📋 Checklist

Please confirm the following (check all that apply):

- [ ] I have `phpunit` and/or `behat` tests that cover my changes or additions.
- [ ] Code passes the code checker without errors and warnings.
- [ ] Code passes the moodle-ci/cd pipeline on all supported Moodle versions or the ones the plugin supports.
- [x ] Code does not have `var_dump()` or `var_export` or any other debugging statements (or commented out code) that
  should not appear on the productive branch.
- [ ] Code only uses language strings instead of hard-coded strings.
- [x ] If there are changes in the database: I updated/created the necessary upgrade steps in `db/upgrade.php` and
  updated the `version.php`.
- [ ] If there are changes in javascript: I build new `.min` files with the `grunt amd` command.
- [ ] If it is a Moodle update PR: I read the release notes, updated the `version.php` and the `CHANGES.md`.
  I ran all tests thoroughly checking for errors. I checked if bootstrap had any changes/deprecations that require
  changes in the plugins UI.

---

### 🔍 Related Issues

- Related to #320